### PR TITLE
PAY-488 Export the CPP and EI constants for PIER

### DIFF
--- a/lib/taxman.rb
+++ b/lib/taxman.rb
@@ -3,6 +3,7 @@
 require_relative "taxman/version"
 
 # Tax factors
+require_relative "taxman/taxman2023/cpp/constants"
 require_relative "taxman/taxman2023/f5"
 require_relative "taxman/taxman2023/f5_a"
 require_relative "taxman/taxman2023/f5_b"

--- a/lib/taxman/taxman2023/c.rb
+++ b/lib/taxman/taxman2023/c.rb
@@ -3,7 +3,6 @@
 module Taxman2023
   # Calculates the CPP contribution for the period
   class C
-    CPP_MAX = 3_754_45.to_d
     attr_reader :pi, :p, :pm, :d, :b_pensionable
 
     def initialize(pi:, p:, pm:, d:, b_pensionable:)
@@ -23,7 +22,7 @@ module Taxman2023
     end
 
     def cpp_max
-      [(CPP_MAX * pm / 12) - d, 0].max
+      [(Cpp::MAX * pm / 12) - d, 0].max
     end
 
     # Calculates the CPP for an employee.
@@ -35,9 +34,9 @@ module Taxman2023
     # tested scenarios.
     def cpp_calculated
       i_pensionable = pi - b_pensionable
-      cpp = (i_pensionable - (3_500_00.to_d / p)) * 0.0595
+      cpp = (i_pensionable - (Cpp::BASIC_EXEMPTION / p)) * Cpp::RATE
 
-      [cpp, 0].max + (b_pensionable * 0.0595)
+      [cpp, 0].max + (b_pensionable * Cpp::RATE)
     end
   end
 end

--- a/lib/taxman/taxman2023/cpp/constants.rb
+++ b/lib/taxman/taxman2023/cpp/constants.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+require "bigdecimal/util"
+
+module Taxman2023
+  module Cpp
+    # Bag to hold all of the CPP constants for 2023
+    MAXIMUM_PENSIONABLE = 66_600_00.to_d
+    MAX = 3_754_45.to_d
+    BASIC_EXEMPTION = 3_500_00.to_d
+    RATE = 0.0595.to_d
+
+    # Helper method to get the constants as a hash
+    class Constants
+      def self.to_h
+        {
+          cpp_basic_exemption: BASIC_EXEMPTION / 100,
+          cpp_employee_rate: RATE,
+          cpp_employer_matching: BigDecimal("1.0"),
+          cpp_maximum_pensionable: MAXIMUM_PENSIONABLE / 100
+        }
+      end
+    end
+  end
+end

--- a/lib/taxman/taxman2023/ei.rb
+++ b/lib/taxman/taxman2023/ei.rb
@@ -4,7 +4,22 @@ module Taxman2023
   # Calculates the employee's ei contributions for the period
   class Ei
     EI_MAX = 1_002_45.to_d
+    MAXIMUM_INSURABLE = 61_500_00.to_d
+    EMPLOYEE_RATE = 0.0163.to_d
+    EMPLOYER_MATCHING = 1.4.to_d
+
     attr_reader :ie, :d1
+
+    # Helper method to get the constants as a hash
+    class Constants
+      def self.to_h
+        {
+          ei_maximum_insurable: MAXIMUM_INSURABLE / 100,
+          ei_employer_matching: EMPLOYER_MATCHING,
+          ei_employee_rate: EMPLOYEE_RATE
+        }
+      end
+    end
 
     def initialize(ie:, d1:)
       @ie = ie.to_d
@@ -24,7 +39,7 @@ module Taxman2023
     end
 
     def ei_calculated
-      ie * 0.0163
+      ie * EMPLOYEE_RATE
     end
   end
 end

--- a/spec/taxman/taxman2023/c_spec.rb
+++ b/spec/taxman/taxman2023/c_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe Taxman2023::C do
   let(:b_pensionable) { 0 }
 
   context "when the employee has already reached the cpp maximum for the year" do
-    let(:d) { Taxman2023::C::CPP_MAX }
+    let(:d) { Taxman2023::Cpp::MAX }
     let(:pi) { 4_000_00 }
 
     it "calculates zero cpp contribution for this period" do
@@ -17,7 +17,7 @@ RSpec.describe Taxman2023::C do
   end
 
   context "when the employee will meet and exceed the maximum this period" do
-    let(:d) { Taxman2023::C::CPP_MAX - 100_00 }
+    let(:d) { Taxman2023::Cpp::MAX - 100_00 }
     let(:pi) { 4_000_00 }
 
     it "calculates a cpp contribution of the remaining room" do

--- a/spec/taxman/taxman2023/cpp/constants_spec.rb
+++ b/spec/taxman/taxman2023/cpp/constants_spec.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+RSpec.describe Taxman2023::Cpp::Constants do
+  let(:constants) { described_class.to_h }
+
+  it "has the maximum pensionable income for a year" do
+    expect(constants[:cpp_maximum_pensionable]).to eq 66_600
+  end
+
+  it "has the basic exemption" do
+    expect(constants[:cpp_basic_exemption]).to eq 3_500
+  end
+
+  it "has the employee rate" do
+    expect(constants[:cpp_employee_rate]).to eq 0.0595
+  end
+
+  it "has the employer matching rate" do
+    expect(constants[:cpp_employer_matching]).to eq 1
+  end
+end

--- a/spec/taxman/taxman2023/ei_spec.rb
+++ b/spec/taxman/taxman2023/ei_spec.rb
@@ -35,4 +35,20 @@ RSpec.describe Taxman2023::Ei do
       expect(ei).to eq 50_00
     end
   end
+
+  describe "constants" do
+    let(:constants) { described_class::Constants.to_h }
+
+    it "has the employee rate" do
+      expect(constants[:ei_employee_rate]).to eq 0.0163
+    end
+
+    it "has the employer matching rate" do
+      expect(constants[:ei_employer_matching]).to eq 1.4
+    end
+
+    it "has the maximum insurable earnings for a year" do
+      expect(constants[:ei_maximum_insurable]).to eq 61_500.00
+    end
+  end
 end


### PR DESCRIPTION
PIER need the cpp and ei constants, which we're currently pulling out of jurisdiction data (i.e. waxman).