### PR TITLE
PAY-488 Add support for 2022/CPP+EI

### DIFF
--- a/lib/taxman.rb
+++ b/lib/taxman.rb
@@ -1,88 +1,9 @@
 # frozen_string_literal: true
 
+require "bigdecimal/util"
 require_relative "taxman/version"
-
-# Tax factors
-require_relative "taxman/taxman2023/cpp/constants"
-require_relative "taxman/taxman2023/f5"
-require_relative "taxman/taxman2023/f5_a"
-require_relative "taxman/taxman2023/f5_b"
-require_relative "taxman/taxman2023/a"
-require_relative "taxman/taxman2023/bpaf"
-require_relative "taxman/taxman2023/bpans"
-require_relative "taxman/taxman2023/t3"
-require_relative "taxman/taxman2023/c"
-require_relative "taxman/taxman2023/ei"
-require_relative "taxman/taxman2023/k2_generic"
-require_relative "taxman/taxman2023/k2"
-require_relative "taxman/taxman2023/t4_generic"
-require_relative "taxman/taxman2023/t2_generic"
-require_relative "taxman/taxman2023/a_bonus"
-require_relative "taxman/taxman2023/current_bonus_term"
-require_relative "taxman/taxman2023/ytd_bonus_term"
-require_relative "taxman/taxman2023/t"
-
-# Provincial specific
-require_relative "taxman/taxman2023/ab/k2p"
-require_relative "taxman/taxman2023/ab/t4"
-require_relative "taxman/taxman2023/ab/t2"
-
-require_relative "taxman/taxman2023/bc/k2p"
-require_relative "taxman/taxman2023/bc/t4"
-require_relative "taxman/taxman2023/bc/t2"
-
-require_relative "taxman/taxman2023/mb/k2p"
-require_relative "taxman/taxman2023/mb/t4"
-require_relative "taxman/taxman2023/mb/t2"
-
-require_relative "taxman/taxman2023/nb/k2p"
-require_relative "taxman/taxman2023/nb/t4"
-require_relative "taxman/taxman2023/nb/t2"
-
-require_relative "taxman/taxman2023/nl/k2p"
-require_relative "taxman/taxman2023/nl/t4"
-require_relative "taxman/taxman2023/nl/t2"
-
-require_relative "taxman/taxman2023/ns/k2p"
-require_relative "taxman/taxman2023/ns/t4"
-require_relative "taxman/taxman2023/ns/t2"
-
-require_relative "taxman/taxman2023/nt/k2p"
-require_relative "taxman/taxman2023/nt/t4"
-require_relative "taxman/taxman2023/nt/t2"
-
-require_relative "taxman/taxman2023/nu/k2p"
-require_relative "taxman/taxman2023/nu/t4"
-require_relative "taxman/taxman2023/nu/t2"
-
-require_relative "taxman/taxman2023/on/k2p"
-require_relative "taxman/taxman2023/on/t4"
-require_relative "taxman/taxman2023/on/t2"
-
-require_relative "taxman/taxman2023/pe/k2p"
-require_relative "taxman/taxman2023/pe/t4"
-require_relative "taxman/taxman2023/pe/t2"
-
-require_relative "taxman/taxman2023/sk/k2p"
-require_relative "taxman/taxman2023/sk/t4"
-require_relative "taxman/taxman2023/sk/t2"
-
-require_relative "taxman/taxman2023/yt/k2p"
-require_relative "taxman/taxman2023/yt/t4"
-require_relative "taxman/taxman2023/yt/t2"
-
-# Program structure
-require_relative "taxman/taxman2023/cpp_input"
-require_relative "taxman/taxman2023/ei_input"
-require_relative "taxman/taxman2023/period_input"
-require_relative "taxman/taxman2023/year_input"
-require_relative "taxman/taxman2023/td1_input"
-require_relative "taxman/taxman2023/module_mapper"
-require_relative "taxman/taxman2023/tax_calculator"
-require_relative "taxman/taxman2023/bonus_tax_calculator"
-require_relative "taxman/taxman2023/cpp_calculator"
-require_relative "taxman/taxman2023/ei_calculator"
-require_relative "taxman/taxman2023/calculate"
+require_relative "taxman/taxman2022"
+require_relative "taxman/taxman2023"
 
 module Taxman
   class Error < StandardError; end

--- a/lib/taxman/taxman2022.rb
+++ b/lib/taxman/taxman2022.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+# Taxman for tax year 2022
+module Taxman2022
+  Dir["#{File.dirname(__FILE__)}/taxman2022/**/*.rb"].each { |f| require(f) }
+end

--- a/lib/taxman/taxman2022/cpp.rb
+++ b/lib/taxman/taxman2022/cpp.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+module Taxman2022
+  module Cpp
+    MAXIMUM_PENSIONABLE = 64_900_00.to_d
+    MAX = 3_499_80.to_d
+    BASIC_EXEMPTION = 3_500_00.to_d
+    RATE = 0.0570.to_d
+
+    # A bag to hold the cpp constants for 2022
+    class Constants
+      def self.to_h
+        {
+          cpp_maximum_pensionable: MAXIMUM_PENSIONABLE / 100,
+          cpp_basic_exemption: BASIC_EXEMPTION / 100,
+          cpp_employee_rate: RATE,
+          cpp_employer_matching: 1.0
+        }
+      end
+    end
+  end
+end

--- a/lib/taxman/taxman2022/ei.rb
+++ b/lib/taxman/taxman2022/ei.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+module Taxman2022
+  module Ei
+    EI_MAX = 952_74.to_d
+    MAXIMUM_INSURABLE = 60_300_00.to_d
+    EMPLOYEE_RATE = 0.0158.to_d
+    EMPLOYER_MATCHING = 1.4.to_d
+
+    # A bag to hold the ei constants for 2022
+    class Constants
+      def self.to_h
+        {
+          ei_employee_rate: EMPLOYEE_RATE,
+          ei_employer_matching: EMPLOYER_MATCHING,
+          ei_maximum_insurable: MAXIMUM_INSURABLE / 100
+        }
+      end
+    end
+  end
+end

--- a/lib/taxman/taxman2023.rb
+++ b/lib/taxman/taxman2023.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+# Taxman for tax year 2023
+module Taxman2023
+  require_relative "taxman2023/k2_generic"
+  require_relative "taxman2023/t2_generic"
+  require_relative "taxman2023/t4_generic"
+
+  Dir["#{File.dirname(__FILE__)}/taxman2023/**/*.rb"].each do |file|
+    next if Pathname.new(file).basename.to_s == "module_mapper.rb"
+
+    require(file)
+  end
+
+  require_relative "taxman2023/module_mapper"
+end

--- a/lib/taxman/taxman2023/cpp/constants.rb
+++ b/lib/taxman/taxman2023/cpp/constants.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require "bigdecimal/util"
-
 module Taxman2023
   module Cpp
     # Bag to hold all of the CPP constants for 2023

--- a/lib/taxman/taxman2023/f5_a.rb
+++ b/lib/taxman/taxman2023/f5_a.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require "bigdecimal/util"
-
 module Taxman2023
   # Calculates the F5A factor
   class F5A

--- a/lib/taxman/taxman2023/f5_b.rb
+++ b/lib/taxman/taxman2023/f5_b.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require "bigdecimal/util"
-
 module Taxman2023
   # Calculates the F5B factor
   class F5B

--- a/spec/taxman/taxman2022/cpp_spec.rb
+++ b/spec/taxman/taxman2022/cpp_spec.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+RSpec.describe Taxman2022::Cpp do
+  let(:constants) { described_class::Constants.to_h }
+
+  it "has the maximum pensionable income for a year" do
+    expect(constants[:cpp_maximum_pensionable]).to eq 64_900.00
+  end
+
+  it "has the basic exemption" do
+    expect(constants[:cpp_basic_exemption]).to eq 3_500.00
+  end
+
+  it "has the employee rate" do
+    expect(constants[:cpp_employee_rate]).to eq 0.0570
+  end
+
+  it "has the employer matching rate" do
+    expect(constants[:cpp_employer_matching]).to eq 1
+  end
+end

--- a/spec/taxman/taxman2022/ei_spec.rb
+++ b/spec/taxman/taxman2022/ei_spec.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+RSpec.describe Taxman2022::Ei do
+  let(:constants) { described_class::Constants.to_h }
+
+  it "has the employee rate" do
+    expect(constants[:ei_employee_rate]).to eq 0.0158
+  end
+
+  it "has the employer matching rate" do
+    expect(constants[:ei_employer_matching]).to eq 1.4
+  end
+
+  it "has the maximum insurable earnings for a year" do
+    expect(constants[:ei_maximum_insurable]).to eq 60_300.00
+  end
+end


### PR DESCRIPTION
Not full FY2022 support, but we can export the constants that PIER requires easily enough.