### PR TITLE
PAY-501 Add FY2021 support for CPP+EI

### DIFF
--- a/lib/taxman.rb
+++ b/lib/taxman.rb
@@ -2,6 +2,7 @@
 
 require "bigdecimal/util"
 require_relative "taxman/version"
+require_relative "taxman/taxman2021"
 require_relative "taxman/taxman2022"
 require_relative "taxman/taxman2023"
 

--- a/lib/taxman/taxman2021.rb
+++ b/lib/taxman/taxman2021.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+# Taxman for tax year 2021
+module Taxman2021
+  Dir["#{File.dirname(__FILE__)}/taxman2021/**/*.rb"].each { |f| require(f) }
+end

--- a/lib/taxman/taxman2021/cpp.rb
+++ b/lib/taxman/taxman2021/cpp.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+module Taxman2021
+  module Cpp
+    MAXIMUM_PENSIONABLE = 61_600_00.to_d
+    MAX = 3_166_45.to_d
+    BASIC_EXEMPTION = 3_500_00.to_d
+    RATE = 0.0545.to_d
+
+    # A bag to hold the cpp constants for 2021
+    class Constants
+      def self.to_h
+        {
+          cpp_maximum_pensionable: MAXIMUM_PENSIONABLE / 100,
+          cpp_basic_exemption: BASIC_EXEMPTION / 100,
+          cpp_employee_rate: RATE,
+          cpp_employer_matching: 1.0
+        }
+      end
+    end
+  end
+end

--- a/lib/taxman/taxman2021/ei.rb
+++ b/lib/taxman/taxman2021/ei.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+module Taxman2021
+  module Ei
+    EI_MAX = 889_54.to_d
+    MAXIMUM_INSURABLE = 56_300_00.to_d
+    EMPLOYEE_RATE = 0.0158.to_d
+    EMPLOYER_MATCHING = 1.4.to_d
+
+    # A bag to hold the ei constants for 2022
+    class Constants
+      def self.to_h
+        {
+          ei_employee_rate: EMPLOYEE_RATE,
+          ei_employer_matching: EMPLOYER_MATCHING,
+          ei_maximum_insurable: MAXIMUM_INSURABLE / 100
+        }
+      end
+    end
+  end
+end

--- a/spec/taxman/taxman2021/cpp_spec.rb
+++ b/spec/taxman/taxman2021/cpp_spec.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+RSpec.describe Taxman2021::Cpp do
+  let(:constants) { described_class::Constants.to_h }
+
+  it "has the maximum pensionable income for a year" do
+    expect(constants[:cpp_maximum_pensionable]).to eq 61_600.00
+  end
+
+  it "has the basic exemption" do
+    expect(constants[:cpp_basic_exemption]).to eq 3_500.00
+  end
+
+  it "has the employee rate" do
+    expect(constants[:cpp_employee_rate]).to eq 0.0545
+  end
+
+  it "has the employer matching rate" do
+    expect(constants[:cpp_employer_matching]).to eq 1
+  end
+end

--- a/spec/taxman/taxman2021/ei_spec.rb
+++ b/spec/taxman/taxman2021/ei_spec.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+RSpec.describe Taxman2021::Ei do
+  let(:constants) { described_class::Constants.to_h }
+
+  it "has the employee rate" do
+    expect(constants[:ei_employee_rate]).to eq 0.0158
+  end
+
+  it "has the employer matching rate" do
+    expect(constants[:ei_employer_matching]).to eq 1.4
+  end
+
+  it "has the maximum insurable earnings for a year" do
+    expect(constants[:ei_maximum_insurable]).to eq 56_300.00
+  end
+end


### PR DESCRIPTION
We want PIER support for FY2021, so we need to add those to the tax engine