### PR TITLE
BUG-8143 Use pi and ie for cpp/ei k2 shields

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -20,5 +20,8 @@ Style/StringLiteralsInInterpolation:
   Enabled: true
   EnforcedStyle: double_quotes
 
+RSpec/MultipleMemoizedHelpers:
+  Enabled: false
+
 Layout/LineLength:
   Max: 120

--- a/lib/taxman/taxman2023/bonus_tax_calculator.rb
+++ b/lib/taxman/taxman2023/bonus_tax_calculator.rb
@@ -35,7 +35,9 @@ module Taxman2023
                         .amount
 
       taxes_with_bonus = TaxCalculator.new(context: context.merge(a: a_bonus)).calculate
-      taxes_without_bonus = TaxCalculator.new(context: context.merge(a: a_without_bonus, b: 0)).calculate
+      taxes_without_bonus = TaxCalculator
+                            .new(context: context.merge(zeroed_bonus_terms(context, a_without_bonus)))
+                            .calculate
 
       federal_tax = (taxes_with_bonus[:t1] - taxes_without_bonus[:t1])
       provincial_tax = (taxes_with_bonus[:t2] - taxes_without_bonus[:t2])
@@ -51,6 +53,8 @@ module Taxman2023
       }
     end
 
+    private
+
     def small_pay_amount(b)
       federal_tax = (b * 0.1)
       provincial_tax = (b * 0.05)
@@ -63,6 +67,16 @@ module Taxman2023
         taxes_with_bonus: {},
         taxes_without_bonus: {}
       }
+    end
+
+    def current_bonus_terms
+      %i[b b_pensionable b_insurable]
+    end
+
+    def zeroed_bonus_terms(context, a_without_bonus)
+      context
+        .merge(a: a_without_bonus)
+        .merge(current_bonus_terms.to_h { |term| [term, 0] })
     end
   end
 end

--- a/lib/taxman/taxman2023/calculate.rb
+++ b/lib/taxman/taxman2023/calculate.rb
@@ -36,12 +36,23 @@ module Taxman2023
 
       # The non bonus tax calculation should not have the bonus, but we need it for the bonus tax calculation
       # Could definitely need a refactor
-      context.merge!(TaxCalculator.new(context: context.merge(b: 0, b1: 0)).calculate.except(:b, :b1))
+      context
+        .merge!(TaxCalculator.new(context: context_without_bonus(context))
+        .calculate
+        .except(*bonus_symbols))
       context.merge!(BonusTaxCalculator.new(context: context).calculate) if context[:b] >= 0
       context.merge!(CppCalculator.new(context: context).calculate)
       context.merge!(EiCalculator.new(context: context).calculate)
 
       context
+    end
+
+    def bonus_symbols
+      %i[b b1 b_insurable b1_insurable b_pensionable b1_pensionable]
+    end
+
+    def context_without_bonus(context)
+      context.merge(bonus_symbols.to_h { |sym| [sym, 0] })
     end
   end
 end

--- a/lib/taxman/taxman2023/cpp_input.rb
+++ b/lib/taxman/taxman2023/cpp_input.rb
@@ -16,6 +16,7 @@ module Taxman2023
     def translate
       {
         pi: (@pi * 100).to_d,
+        pi_periodic: (@pi * 100).to_d - (@b_pensionable * 100).to_d,
         b_pensionable: (@b_pensionable * 100).to_d,
         d: (@d * 100).to_d,
         pm: @pm

--- a/lib/taxman/taxman2023/ei_input.rb
+++ b/lib/taxman/taxman2023/ei_input.rb
@@ -4,15 +4,19 @@ module Taxman2023
   # This input collects the factors relevant to ei calculation
   class EiInput
     def initialize(insurable_income_this_period:,
-                   employees_ytd_contributions:)
+                   employees_ytd_contributions:,
+                   insurable_non_periodic_income_this_period: 0)
       @ie = insurable_income_this_period
+      @b_insurable = insurable_non_periodic_income_this_period
       @d1 = employees_ytd_contributions
     end
 
     def translate
       {
         ie: (@ie * 100).to_d,
-        d1: (@d1 * 100).to_d
+        d1: (@d1 * 100).to_d,
+        ie_periodic: (@ie * 100).to_d - (@b_insurable * 100).to_d,
+        b_insurable: (@b_insurable * 100).to_d
       }
     end
   end

--- a/lib/taxman/taxman2023/k2_generic.rb
+++ b/lib/taxman/taxman2023/k2_generic.rb
@@ -3,25 +3,44 @@
 module Taxman2023
   # Calculates the generic k2 factor
   class K2Generic
-    attr_reader :i, # Income in the period
-                :b, # Bonus in the period
-                :b1, # Bonus YTD
+    attr_reader :pi, # Pensionable income in the period
+                :pi_periodic, # Pensionable periodic income this period
+                :b_pensionable, # Pensionable bonus in the period
+                :b1_pensionable, # Pensionable bonus YTD
+                :ie, # Insurable income in the period
+                :ie_periodic, # Insurable periodic income this period
+                :b_insurable, # Insurable bonus in the period
+                :b1_insurable, # Insurable bonus YTD
                 :p # Number of periods
 
+    # rubocop:disable Metrics/ParameterLists
     def initialize(
-      i:,
-      b:,
-      b1:,
+      pi:,
+      pi_periodic:,
+      b_pensionable:,
+      b1_pensionable:,
+      ie:,
+      ie_periodic:,
+      b_insurable:,
+      b1_insurable:,
       p:
     )
-      @i = i.to_d
-      @b = b.to_d
-      @b1 = b1.to_d
+      @pi = pi.to_d
+      @pi_periodic = pi_periodic.to_d
+      @b_pensionable = b_pensionable.to_d
+      @b1_pensionable = b1_pensionable.to_d
+
+      @ie = ie.to_d
+      @ie_periodic = ie_periodic.to_d
+      @b_insurable = b_insurable.to_d
+      @b1_insurable = b1_insurable.to_d
+
       @p = p
     end
+    # rubocop:enable Metrics/ParameterLists
 
     def self.params
-      %i[i b b1 p]
+      %i[pi pi_periodic b_pensionable b1_pensionable ie ie_periodic b_insurable b1_insurable p]
     end
 
     def rate
@@ -41,7 +60,7 @@ module Taxman2023
     end
 
     def cpp_portion
-      ((i + ((b + b1) / p)) - (3_500_00.to_d / p)) * 0.0595
+      ((pi_periodic + ((b_pensionable + b1_pensionable) / p)) - (Cpp::BASIC_EXEMPTION / p)) * Cpp::RATE
     end
 
     def ei_credit
@@ -49,11 +68,11 @@ module Taxman2023
     end
 
     def max_ei_credit
-      1_002_45.to_d
+      Ei::EI_MAX
     end
 
     def ei_portion
-      (i + ((b + b1) / p)) * 0.0163
+      (ie_periodic + ((b_insurable + b1_insurable) / p)) * Ei::EMPLOYEE_RATE
     end
 
     def lower_cpp_rate

--- a/lib/taxman/taxman2023/tax_calculator.rb
+++ b/lib/taxman/taxman2023/tax_calculator.rb
@@ -28,6 +28,12 @@ module Taxman2023
       k3p
       province
       l
+      pi
+      ie
+      b_pensionable
+      b_insurable
+      b1_pensionable
+      b1_insurable
     ].freeze
 
     def initialize(context:)

--- a/lib/taxman/taxman2023/year_input.rb
+++ b/lib/taxman/taxman2023/year_input.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# rubocop:disable Metrics/ParameterLists
+# rubocop:disable Metrics/ParameterLists, Metrics/MethodLength
 module Taxman2023
   # This input collects the ytd and general inputs
   class YearInput
@@ -12,9 +12,13 @@ module Taxman2023
       annual_deductions: 0, # F1
       ytd_rsp_bonus_deductions: 0, # F4
       other_federal_deductions: 0, # K3
-      other_provincial_deductions: 0 # K3P
+      other_provincial_deductions: 0, # K3P
+      ytd_pensionable_bonus: nil,
+      ytd_insurable_bonus: nil
     )
       @b1 = ytd_bonus
+      @b1_pensionable = ytd_pensionable_bonus || ytd_bonus
+      @b1_insurable = ytd_insurable_bonus || ytd_bonus
       @f1 = annual_deductions
       @f4 = ytd_rsp_bonus_deductions
       @p = pay_periods
@@ -27,6 +31,8 @@ module Taxman2023
     def translate
       {
         b1: (@b1 * 100).to_d,
+        b1_pensionable: (@b1_pensionable * 100).to_d,
+        b1_insurable: (@b1_insurable * 100).to_d,
         f1: (@f1 * 100).to_d,
         f4: (@f4 * 100).to_d,
         p: @p,
@@ -38,4 +44,4 @@ module Taxman2023
     end
   end
 end
-# rubocop:enable Metrics/ParameterLists
+# rubocop:enable Metrics/ParameterLists, Metrics/MethodLength

--- a/spec/integration/taxman2023/bug_8143_spec.rb
+++ b/spec/integration/taxman2023/bug_8143_spec.rb
@@ -14,9 +14,9 @@ RSpec.describe Taxman2023::Calculate do
 
   let(:p) do
     Taxman2023::PeriodInput.new(
-      taxable_periodic_income: 3_225,
+      taxable_periodic_income: 3_646.40 + 9.37,
       taxable_non_periodic_income: 0,
-      province: "bc"
+      province: "mb"
     )
   end
 
@@ -29,37 +29,44 @@ RSpec.describe Taxman2023::Calculate do
     )
   end
 
-  let(:t) { Taxman2023::Td1Input.new(federal_personal_amount: 15_000, provincial_personal_amount: 11_981) }
+  let(:t) do
+    Taxman2023::Td1Input.new(
+      federal_personal_amount: nil,
+      provincial_personal_amount: nil,
+      additional_tax_deductions: 0
+    )
+  end
 
   let(:c) do
     Taxman2023::CppInput.new(
-      pensionable_income_this_period: 3_225,
-      ytd_contributions: 0,
+      pensionable_income_this_period: 3_655.77,
+      pensionable_non_periodic_income_this_period: 0,
+      ytd_contributions: 1255.37,
       contribution_months_this_year: 12
     )
   end
 
   let(:e) do
     Taxman2023::EiInput.new(
-      insurable_income_this_period: 3_175,
+      insurable_income_this_period: 0,
       employees_ytd_contributions: 0
     )
   end
 
   it "matches PDOC's federal tax" do
-    expect(calculate[:federal_tax]).to eq 423.67
+    expect(calculate[:federal_tax]).to eq 516.88
   end
 
   it "matches PDOC's provincial tax" do
-    expect(calculate[:provincial_tax]).to eq 168.25
+    expect(calculate[:provincial_tax]).to be_within(0.1).of 401.87
   end
 
   it "matches PDOC's CPP deduction" do
-    expect(calculate[:employee_cpp_contribution]).to eq 183.88
+    expect(calculate[:employee_cpp_contribution]).to be_within(0.1).of 209.51
   end
 
   it "matches PDOC's EI calculation" do
-    expect(calculate[:employee_ei_contribution]).to eq 51.75
+    expect(calculate[:employee_ei_contribution]).to eq 0
   end
 end
 # rubocop:enable RSpec/FilePath, RSpec/MultipleMemoizedHelpers

--- a/spec/integration/taxman2023/bug_8143_spec.rb
+++ b/spec/integration/taxman2023/bug_8143_spec.rb
@@ -69,4 +69,4 @@ RSpec.describe Taxman2023::Calculate do
     expect(calculate[:employee_ei_contribution]).to eq 0
   end
 end
-# rubocop:enable RSpec/FilePath, RSpec/MultipleMemoizedHelpers
+# rubocop:enable RSpec/FilePath

--- a/spec/integration/taxman2023/demo_test_spec.rb
+++ b/spec/integration/taxman2023/demo_test_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# rubocop:disable RSpec/FilePath, RSpec/MultipleMemoizedHelpers
+# rubocop:disable RSpec/FilePath
 RSpec.describe Taxman2023::Calculate do
   let(:calculate) do
     described_class.new(

--- a/spec/integration/taxman2023/pay_4440_spec.rb
+++ b/spec/integration/taxman2023/pay_4440_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# rubocop:disable RSpec/FilePath, RSpec/MultipleMemoizedHelpers
+# rubocop:disable RSpec/FilePath
 RSpec.describe Taxman2023::Calculate do
   let(:calculate) do
     described_class.new(

--- a/spec/integration/taxman2023/pay_447_spec.rb
+++ b/spec/integration/taxman2023/pay_447_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# rubocop:disable RSpec/FilePath, RSpec/MultipleMemoizedHelpers
+# rubocop:disable RSpec/FilePath
 RSpec.describe Taxman2023::Calculate do
   let(:calculate) do
     described_class.new(

--- a/spec/integration/taxman2023/test10_spec.rb
+++ b/spec/integration/taxman2023/test10_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# rubocop:disable RSpec/FilePath, RSpec/MultipleMemoizedHelpers
+# rubocop:disable RSpec/FilePath
 RSpec.describe Taxman2023::Calculate do
   let(:calculate) do
     described_class.new(

--- a/spec/integration/taxman2023/test11_spec.rb
+++ b/spec/integration/taxman2023/test11_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# rubocop:disable RSpec/FilePath, RSpec/MultipleMemoizedHelpers
+# rubocop:disable RSpec/FilePath
 RSpec.describe Taxman2023::Calculate do
   let(:calculate) do
     described_class.new(

--- a/spec/integration/taxman2023/test12_spec.rb
+++ b/spec/integration/taxman2023/test12_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# rubocop:disable RSpec/FilePath, RSpec/MultipleMemoizedHelpers
+# rubocop:disable RSpec/FilePath
 RSpec.describe Taxman2023::Calculate do
   let(:calculate) do
     described_class.new(

--- a/spec/integration/taxman2023/test13_spec.rb
+++ b/spec/integration/taxman2023/test13_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# rubocop:disable RSpec/FilePath, RSpec/MultipleMemoizedHelpers
+# rubocop:disable RSpec/FilePath
 RSpec.describe Taxman2023::Calculate do
   let(:calculate) do
     described_class.new(

--- a/spec/integration/taxman2023/test14_spec.rb
+++ b/spec/integration/taxman2023/test14_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# rubocop:disable RSpec/FilePath, RSpec/MultipleMemoizedHelpers
+# rubocop:disable RSpec/FilePath
 RSpec.describe Taxman2023::Calculate do
   let(:calculate) do
     described_class.new(

--- a/spec/integration/taxman2023/test15_spec.rb
+++ b/spec/integration/taxman2023/test15_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# rubocop:disable RSpec/FilePath, RSpec/MultipleMemoizedHelpers
+# rubocop:disable RSpec/FilePath
 RSpec.describe Taxman2023::Calculate do
   let(:calculate) do
     described_class.new(

--- a/spec/integration/taxman2023/test16_spec.rb
+++ b/spec/integration/taxman2023/test16_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# rubocop:disable RSpec/FilePath, RSpec/MultipleMemoizedHelpers
+# rubocop:disable RSpec/FilePath
 RSpec.describe Taxman2023::Calculate do
   let(:calculate) do
     described_class.new(

--- a/spec/integration/taxman2023/test17_spec.rb
+++ b/spec/integration/taxman2023/test17_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# rubocop:disable RSpec/FilePath, RSpec/MultipleMemoizedHelpers
+# rubocop:disable RSpec/FilePath
 RSpec.describe Taxman2023::Calculate do
   let(:calculate) do
     described_class.new(
@@ -49,6 +49,7 @@ RSpec.describe Taxman2023::Calculate do
   let(:e) do
     Taxman2023::EiInput.new(
       insurable_income_this_period: 100_500.00,
+      insurable_non_periodic_income_this_period: 100_000.00,
       employees_ytd_contributions: 163.00
     )
   end
@@ -75,6 +76,10 @@ RSpec.describe Taxman2023::Calculate do
 
   it "matches PDOC's EI calculation" do
     expect(calculate[:employee_ei_contribution]).to eq 839.45
+  end
+
+  it "matches the f5b" do
+    expect(calculate[:f5b]).to be_within(1).of 541_75
   end
 end
 # rubocop:enable RSpec/FilePath, RSpec/MultipleMemoizedHelpers

--- a/spec/integration/taxman2023/test18_spec.rb
+++ b/spec/integration/taxman2023/test18_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# rubocop:disable RSpec/FilePath, RSpec/MultipleMemoizedHelpers
+# rubocop:disable RSpec/FilePath
 RSpec.describe Taxman2023::Calculate do
   let(:calculate) do
     described_class.new(

--- a/spec/integration/taxman2023/test19_spec.rb
+++ b/spec/integration/taxman2023/test19_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# rubocop:disable RSpec/FilePath, RSpec/MultipleMemoizedHelpers
+# rubocop:disable RSpec/FilePath
 RSpec.describe Taxman2023::Calculate do
   let(:calculate) do
     described_class.new(

--- a/spec/integration/taxman2023/test1_spec.rb
+++ b/spec/integration/taxman2023/test1_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# rubocop:disable RSpec/FilePath, RSpec/MultipleMemoizedHelpers
+# rubocop:disable RSpec/FilePath
 RSpec.describe Taxman2023::Calculate do
   let(:calculate) do
     described_class.new(

--- a/spec/integration/taxman2023/test20_spec.rb
+++ b/spec/integration/taxman2023/test20_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# rubocop:disable RSpec/FilePath, RSpec/MultipleMemoizedHelpers
+# rubocop:disable RSpec/FilePath
 RSpec.describe Taxman2023::Calculate do
   let(:calculate) do
     described_class.new(

--- a/spec/integration/taxman2023/test21_spec.rb
+++ b/spec/integration/taxman2023/test21_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# rubocop:disable RSpec/FilePath, RSpec/MultipleMemoizedHelpers
+# rubocop:disable RSpec/FilePath
 RSpec.describe Taxman2023::Calculate do
   let(:calculate) do
     described_class.new(

--- a/spec/integration/taxman2023/test22_spec.rb
+++ b/spec/integration/taxman2023/test22_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# rubocop:disable RSpec/FilePath, RSpec/MultipleMemoizedHelpers
+# rubocop:disable RSpec/FilePath
 RSpec.describe Taxman2023::Calculate do
   let(:calculate) do
     described_class.new(

--- a/spec/integration/taxman2023/test23_spec.rb
+++ b/spec/integration/taxman2023/test23_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# rubocop:disable RSpec/FilePath, RSpec/MultipleMemoizedHelpers
+# rubocop:disable RSpec/FilePath
 RSpec.describe Taxman2023::Calculate do
   let(:calculate) do
     described_class.new(

--- a/spec/integration/taxman2023/test3_spec.rb
+++ b/spec/integration/taxman2023/test3_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# rubocop:disable RSpec/FilePath, RSpec/MultipleMemoizedHelpers
+# rubocop:disable RSpec/FilePath
 RSpec.describe Taxman2023::Calculate do
   let(:calculate) do
     described_class.new(

--- a/spec/integration/taxman2023/test4_spec.rb
+++ b/spec/integration/taxman2023/test4_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# rubocop:disable RSpec/FilePath, RSpec/MultipleMemoizedHelpers
+# rubocop:disable RSpec/FilePath
 RSpec.describe Taxman2023::Calculate do
   let(:calculate) do
     described_class.new(

--- a/spec/integration/taxman2023/test5_spec.rb
+++ b/spec/integration/taxman2023/test5_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# rubocop:disable RSpec/FilePath, RSpec/MultipleMemoizedHelpers
+# rubocop:disable RSpec/FilePath
 RSpec.describe Taxman2023::Calculate do
   let(:calculate) do
     described_class.new(

--- a/spec/integration/taxman2023/test6_spec.rb
+++ b/spec/integration/taxman2023/test6_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# rubocop:disable RSpec/FilePath, RSpec/MultipleMemoizedHelpers
+# rubocop:disable RSpec/FilePath
 RSpec.describe Taxman2023::Calculate do
   let(:calculate) do
     described_class.new(

--- a/spec/integration/taxman2023/test7_spec.rb
+++ b/spec/integration/taxman2023/test7_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# rubocop:disable RSpec/FilePath, RSpec/MultipleMemoizedHelpers
+# rubocop:disable RSpec/FilePath
 RSpec.describe Taxman2023::Calculate do
   let(:calculate) do
     described_class.new(

--- a/spec/integration/taxman2023/test8_spec.rb
+++ b/spec/integration/taxman2023/test8_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# rubocop:disable RSpec/FilePath, RSpec/MultipleMemoizedHelpers
+# rubocop:disable RSpec/FilePath
 RSpec.describe Taxman2023::Calculate do
   let(:calculate) do
     described_class.new(

--- a/spec/integration/taxman2023/test9_spec.rb
+++ b/spec/integration/taxman2023/test9_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# rubocop:disable RSpec/FilePath, RSpec/MultipleMemoizedHelpers
+# rubocop:disable RSpec/FilePath
 RSpec.describe Taxman2023::Calculate do
   let(:calculate) do
     described_class.new(

--- a/spec/taxman/taxman2023/a_bonus_spec.rb
+++ b/spec/taxman/taxman2023/a_bonus_spec.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-# rubocop:disable RSpec/MultipleMemoizedHelpers
 RSpec.describe Taxman2023::ABonus do
   let(:a) do
     described_class.new(

--- a/spec/taxman/taxman2023/a_spec.rb
+++ b/spec/taxman/taxman2023/a_spec.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-# rubocop:disable RSpec/MultipleMemoizedHelpers
 RSpec.describe Taxman2023::A do
   let(:a) do
     described_class

--- a/spec/taxman/taxman2023/bonus_tax_calculator_spec.rb
+++ b/spec/taxman/taxman2023/bonus_tax_calculator_spec.rb
@@ -21,7 +21,15 @@ RSpec.describe Taxman2023::BonusTaxCalculator do
       c: 472_00.to_d,
       k3: 0, # Other authorized per period federal deductions
       k3p: 0, # Other authorized per period provincial deductions
-      l: 0
+      l: 0,
+      pi: i + b,
+      pi_periodic: i,
+      ie: i + b,
+      ie_periodic: i,
+      b_pensionable: b,
+      b_insurable: b,
+      b1_pensionable: 1_000_00,
+      b1_insurable: 1_000_00
     }
   end
 

--- a/spec/taxman/taxman2023/calculate_spec.rb
+++ b/spec/taxman/taxman2023/calculate_spec.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-# rubocop:disable RSpec/MultipleMemoizedHelpers
 RSpec.describe Taxman2023::Calculate do
   let(:calculate) do
     described_class.new(
@@ -14,7 +13,11 @@ RSpec.describe Taxman2023::Calculate do
 
   context "with $156k, weekly schedule, $1k bonus YTD, $5k bonus current" do
     let(:p) do
-      Taxman2023::PeriodInput.new(taxable_periodic_income: 3_000, taxable_non_periodic_income: 5_000, province: "on")
+      Taxman2023::PeriodInput.new(
+        taxable_periodic_income: 3_000,
+        taxable_non_periodic_income: 5_000,
+        province: "on"
+      )
     end
 
     let(:y) do
@@ -31,6 +34,7 @@ RSpec.describe Taxman2023::Calculate do
     let(:c) do
       Taxman2023::CppInput.new(
         pensionable_income_this_period: 8_000,
+        pensionable_non_periodic_income_this_period: 5_000,
         ytd_contributions: 0,
         contribution_months_this_year: 12
       )
@@ -39,6 +43,7 @@ RSpec.describe Taxman2023::Calculate do
     let(:e) do
       Taxman2023::EiInput.new(
         insurable_income_this_period: 8_000,
+        insurable_non_periodic_income_this_period: 5_000,
         employees_ytd_contributions: 0
       )
     end
@@ -90,7 +95,8 @@ RSpec.describe Taxman2023::Calculate do
     let(:p) do
       Taxman2023::PeriodInput.new(
         taxable_periodic_income: 3_076.92,
-        taxable_non_periodic_income: 21_619, province: "sk"
+        taxable_non_periodic_income: 21_619,
+        province: "sk"
       )
     end
 
@@ -218,6 +224,7 @@ RSpec.describe Taxman2023::Calculate do
     let(:e) do
       Taxman2023::EiInput.new(
         insurable_income_this_period: 1_000,
+        insurable_non_periodic_income_this_period: 1_000,
         employees_ytd_contributions: 1_002.45
       )
     end

--- a/spec/taxman/taxman2023/cpp_input_spec.rb
+++ b/spec/taxman/taxman2023/cpp_input_spec.rb
@@ -13,7 +13,17 @@ RSpec.describe Taxman2023::CppInput do
   let(:ytd) { 114 }
   let(:pm) { 12 }
 
+  let(:cra_form) do
+    {
+      pi: 3_500_00.to_d,
+      d: 114_00.to_d,
+      pm: 12,
+      b_pensionable: 0,
+      pi_periodic: 3_500_00.to_d
+    }
+  end
+
   it "converts its inputs into CRA form" do
-    expect(cpp_input.translate).to eq({ pi: 3_500_00.to_d, d: 114_00.to_d, pm: 12, b_pensionable: 0 })
+    expect(cpp_input.translate).to eq cra_form
   end
 end

--- a/spec/taxman/taxman2023/ei_input_spec.rb
+++ b/spec/taxman/taxman2023/ei_input_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe Taxman2023::EiInput do
   let(:ie) { 3_500 }
   let(:d1) { 1_000 }
   let(:b_insurable) { 500 }
-  
+
   let(:cra_form) do
     {
       ie: 3_500_00.to_d,

--- a/spec/taxman/taxman2023/ei_input_spec.rb
+++ b/spec/taxman/taxman2023/ei_input_spec.rb
@@ -4,14 +4,25 @@ RSpec.describe Taxman2023::EiInput do
   let(:ei_input) do
     described_class.new(
       insurable_income_this_period: ie,
-      employees_ytd_contributions: d1
+      employees_ytd_contributions: d1,
+      insurable_non_periodic_income_this_period: b_insurable
     )
   end
 
   let(:ie) { 3_500 }
   let(:d1) { 1_000 }
+  let(:b_insurable) { 500 }
+  
+  let(:cra_form) do
+    {
+      ie: 3_500_00.to_d,
+      d1: 1_000_00.to_d,
+      b_insurable: 500_00.00.to_d,
+      ie_periodic: 3_000_00.to_d
+    }
+  end
 
   it "converts its inputs into CRA form" do
-    expect(ei_input.translate).to eq({ ie: 3_500_00.to_d, d1: 1_000_00.to_d })
+    expect(ei_input.translate).to eq cra_form
   end
 end

--- a/spec/taxman/taxman2023/k2_generic_spec.rb
+++ b/spec/taxman/taxman2023/k2_generic_spec.rb
@@ -1,10 +1,23 @@
 # frozen_string_literal: true
 
-# rubocop:disable RSpec/MultipleMemoizedHelpers
 RSpec.describe Taxman2023::K2Generic do
-  let(:k2p_obj) { described_class.new(i: i, b: b, b1: b1, p: p) }
+  let(:k2p_obj) { described_class.new(**k2_params) }
   let(:k2p) { k2p_obj.amount }
   let(:b1) { 0 }
+
+  let(:k2_params) do
+    {
+      pi: i + b,
+      pi_periodic: i,
+      b_pensionable: b,
+      b1_pensionable: b1,
+      ie: i + b,
+      ie_periodic: i,
+      b_insurable: b,
+      b1_insurable: b1,
+      p: p
+    }
+  end
 
   before { allow(k2p_obj).to receive(:rate).and_return(0.0505) }
 

--- a/spec/taxman/taxman2023/k2_spec.rb
+++ b/spec/taxman/taxman2023/k2_spec.rb
@@ -1,8 +1,22 @@
 # frozen_string_literal: true
 
 RSpec.describe Taxman2023::K2 do
-  let(:k2) { described_class.new(i: i, b: b, b1: b1, p: p).amount }
+  let(:k2) { described_class.new(**k2_params).amount }
   let(:b1) { 0 }
+
+  let(:k2_params) do
+    {
+      pi: i + b,
+      pi_periodic: i,
+      b_pensionable: b,
+      b1_pensionable: b1,
+      ie: i + b,
+      ie_periodic: i,
+      b_insurable: b,
+      b1_insurable: b1,
+      p: p
+    }
+  end
 
   context "with $54k salary monthly, $1k bonus" do
     let(:i) { 4_500_00 }

--- a/spec/taxman/taxman2023/nl/k2p_spec.rb
+++ b/spec/taxman/taxman2023/nl/k2p_spec.rb
@@ -1,9 +1,22 @@
 # frozen_string_literal: true
 
 RSpec.describe Taxman2023::Nl::K2p do
-  let(:k2p) { described_class.new(i: i, b: b, b1: b1, p: p).amount }
+  let(:k2p) { described_class.new(**k2_params).amount }
   let(:b) { 0 }
   let(:b1) { 0 }
+  let(:k2_params) do
+    {
+      pi: i,
+      pi_periodic: i,
+      b_pensionable: b,
+      b1_pensionable: b1,
+      ie: i,
+      ie_periodic: i,
+      b_insurable: b,
+      b1_insurable: b1,
+      p: p
+    }
+  end
 
   context "with $84k salary monthly" do
     let(:i) { 7_000_00 }

--- a/spec/taxman/taxman2023/nl/t4_spec.rb
+++ b/spec/taxman/taxman2023/nl/t4_spec.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-# rubocop:disable RSpec/MultipleMemoizedHelpers
 RSpec.describe Taxman2023::Nl::T4 do
   let(:t4) { described_class.new(a: a, hd: 0, tcp: tcp, k2p: k2p, k3p: k3p).amount }
   let(:a) { 0 } # Annualized income (comes from `a` calculator)
@@ -9,6 +8,20 @@ RSpec.describe Taxman2023::Nl::T4 do
   let(:p) { 12 } # Number of periods in the year
   let(:tcp) { nil } # Provincial personal exemption, nil to use the table
   let(:k3p) { 0 } # Other non-refundable provincial tax credits
+
+  let(:k2_params) do
+    {
+      pi: i,
+      pi_periodic: i - b,
+      b_pensionable: b,
+      b1_pensionable: b1,
+      ie: i,
+      ie_periodic: i - b,
+      b_insurable: b,
+      b1_insurable: b1,
+      p: p
+    }
+  end
 
   context "with no income in the period" do
     let(:k2p) { 0 }
@@ -20,6 +33,9 @@ RSpec.describe Taxman2023::Nl::T4 do
 
   context "with $84k salary" do
     let(:i) { 7_000_00 }
+    let(:b) { 0 }
+    let(:b1) { 0 }
+    let(:p) { 12 }
     let(:f5a) { 399_15.to_d * (0.01 / 0.0595) } # F5=C*(0.01/0.0595) C from PDOC
     let(:a) do
       Taxman2023::A.new(
@@ -34,7 +50,7 @@ RSpec.describe Taxman2023::Nl::T4 do
       ).amount
     end
 
-    let(:k2p) { Taxman2023::Nl::K2p.new(i: i, b: 0, b1: 0, p: 12).amount }
+    let(:k2p) { Taxman2023::Nl::K2p.new(**k2_params).amount }
 
     # https://docs.google.com/spreadsheets/d/1Kh9TLeYrnnqyr7BkKyuFyAWDOvkUvAlBzFAKLBB3VeQ/edit#gid=562910102
     it "calculates an annualized provincial tax deduction of $8,400.62" do

--- a/spec/taxman/taxman2023/on/k2p_spec.rb
+++ b/spec/taxman/taxman2023/on/k2p_spec.rb
@@ -1,8 +1,22 @@
 # frozen_string_literal: true
 
 RSpec.describe Taxman2023::On::K2p do
-  let(:k2p) { described_class.new(i: i, b: b, b1: b1, p: p).amount }
+  let(:k2p) { described_class.new(**k2_params).amount }
   let(:b1) { 0 }
+
+  let(:k2_params) do
+    {
+      pi: i + b,
+      pi_periodic: i,
+      b_pensionable: b,
+      b1_pensionable: b1,
+      ie: i + b,
+      ie_periodic: i,
+      b_insurable: b,
+      b1_insurable: b1,
+      p: p
+    }
+  end
 
   context "with $54k salary monthly, $1k bonus" do
     let(:i) { 4_500_00 }

--- a/spec/taxman/taxman2023/on/t4_spec.rb
+++ b/spec/taxman/taxman2023/on/t4_spec.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-# rubocop:disable RSpec/MultipleMemoizedHelpers
 RSpec.describe Taxman2023::On::T4 do
   let(:t4) { described_class.new(a: a, hd: 0, tcp: tcp, k2p: k2p, k3p: k3p).amount }
   let(:a) { 0 } # Annualized income (comes from `a` calculator)
@@ -9,6 +8,20 @@ RSpec.describe Taxman2023::On::T4 do
   let(:p) { 12 } # Number of periods in the year
   let(:tcp) { nil } # Provincial personal exemption, nil to use the table
   let(:k3p) { 0 } # Other non-refundable provincial tax credits
+
+  let(:k2_params) do
+    {
+      pi: i,
+      pi_periodic: i,
+      b_pensionable: b,
+      b1_pensionable: b1,
+      ie: i,
+      ie_periodic: i,
+      b_insurable: b,
+      b1_insurable: b1,
+      p: p
+    }
+  end
 
   context "with no income in the period" do
     let(:k2p) { 0 }
@@ -20,6 +33,9 @@ RSpec.describe Taxman2023::On::T4 do
 
   context "with $54k salary" do
     let(:i) { 4_500_00 }
+    let(:b) { 0 }
+    let(:b1) { 0 }
+    let(:p) { 12 }
     let(:f5a) { 250_40 * (0.01 / 0.0595) } # F5=C*(0.01/0.0595) C from PDOC
     let(:a) do
       Taxman2023::A.new(
@@ -34,7 +50,7 @@ RSpec.describe Taxman2023::On::T4 do
       ).amount
     end
 
-    let(:k2p) { Taxman2023::On::K2p.new(i: i, b: 0, b1: 0, p: 12).amount }
+    let(:k2p) { Taxman2023::On::K2p.new(**k2_params).amount }
 
     # https://docs.google.com/spreadsheets/d/1q0tv_4IMqdL23wLRg49VikhXRC5tsy7oxGc5at71fzw/edit#gid=89378561
     it "calculates an annualized provincial tax deduction of $2,106.92" do

--- a/spec/taxman/taxman2023/t3_spec.rb
+++ b/spec/taxman/taxman2023/t3_spec.rb
@@ -5,6 +5,22 @@ RSpec.describe Taxman2023::T3 do
   let(:hd) { 0 }
   let(:tc) { nil }
 
+  let(:b) { 0 }
+  let(:b1) { 0 }
+  let(:k2_params) do
+    {
+      pi: i,
+      pi_periodic: i - b,
+      b_pensionable: b,
+      b1_pensionable: b1,
+      ie: i,
+      ie_periodic: i - b,
+      b_insurable: b,
+      b1_insurable: b1,
+      p: p
+    }
+  end
+
   context "with no income" do
     let(:a) { 0 }
     let(:k2) { 0 }
@@ -15,10 +31,12 @@ RSpec.describe Taxman2023::T3 do
   end
 
   context "with $54,000 a year income" do
+    let(:i) { 4_500_00 }
+    let(:p) { 12 }
     let(:a) do
       Taxman2023::A.new(
         p: 12,
-        i: 4_500_00,
+        i: i,
         f: 0,
         f2: 0,
         f5a: 250_40 * (0.01 / 0.0595), # F5=C*(0.01/0.0595)=from pdoc
@@ -27,7 +45,7 @@ RSpec.describe Taxman2023::T3 do
         f1: 0
       ).amount
     end
-    let(:k2) { Taxman2023::K2.new(i: 4_500_00, b: 0, b1: 0, p: 12).amount }
+    let(:k2) { Taxman2023::K2.new(**k2_params).amount }
 
     it "calculates an annualized tax of $5,069.28" do
       expect(t3).to be_within(0.1).of 5_069_28 # This is from pdoc, they only give us cents
@@ -35,6 +53,8 @@ RSpec.describe Taxman2023::T3 do
   end
 
   context "with $210k yearly income" do
+    let(:i) { 8_750_00 }
+    let(:p) { 24 }
     let(:a) do
       Taxman2023::A.new(
         p: 24,
@@ -48,7 +68,7 @@ RSpec.describe Taxman2023::T3 do
       ).amount
     end
 
-    let(:k2) { Taxman2023::K2.new(i: 8_750_00, b: 0, b1: 0, p: 24).amount }
+    let(:k2) { Taxman2023::K2.new(**k2_params).amount }
 
     it "calculates an annualized tax of $43,594.31" do
       expect(t3).to be_within(0.01).of 43_594_30.56.to_d

--- a/spec/taxman/taxman2023/tax_calculator_spec.rb
+++ b/spec/taxman/taxman2023/tax_calculator_spec.rb
@@ -1,27 +1,38 @@
 # frozen_string_literal: true
 
 RSpec.describe Taxman2023::TaxCalculator do
+  let(:i) { 3_000_00.to_d }
+  let(:b) { 5_000_00.to_d }
+  let(:b1) { 1_000_00.to_d }
   let(:partial_context) do
     {
       p: 52,
-      i: 3_000_00.to_d,
+      pi_periodic: i,
+      ie_periodic: i,
+      i: i,
       f: 0,
       f2: 0,
       f5a: 29_74.79.to_d,
       u1: 0,
       hd: 0,
       f1: 0,
-      b: 5_000_00.to_d,
+      b: b,
       f3: 0,
       f5b: 49_57.98.to_d,
-      b1: 1_000_00.to_d,
+      b1: b1,
       f4: 0,
       f5b_ytd: 9_63.to_d,
       c: 472_00.to_d,
       province: "ON",
       k3: 0, # Other authorized per period federal deductions
       k3p: 0, # Other authorized per period provincial deductions
-      l: 0
+      l: 0,
+      pi: i + b,
+      ie: i + b,
+      b_pensionable: b,
+      b1_pensionable: b1,
+      b_insurable: b,
+      b1_insurable: b1
     }
   end
   let(:context) do

--- a/spec/taxman/taxman2023/td1_input_spec.rb
+++ b/spec/taxman/taxman2023/td1_input_spec.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 # rubocop:disable RSpec/ExampleLength
-# rubocop:disable RSpec/MultipleMemoizedHelpers
 RSpec.describe Taxman2023::Td1Input do
   let(:td1_input) do
     described_class.new(

--- a/spec/taxman/taxman2023/year_input_spec.rb
+++ b/spec/taxman/taxman2023/year_input_spec.rb
@@ -19,13 +19,15 @@ RSpec.describe Taxman2023::YearInput do
     expect(year_input.translate).to eq(
       {
         b1: 1_00.to_d,
+        b1_insurable: 1_00.to_d,
+        b1_pensionable: 1_00.to_d,
         f1: 2_00.to_d,
         f4: 3_00.to_d,
         p: 12,
         f5b_ytd: 4_00.to_d,
         employer_ei_multiple: 1.3.to_d,
-        k3: 1_000_00,
-        k3p: 978_00
+        k3: 1_000_00.to_d,
+        k3p: 978_00.to_d
       }
     )
   end
@@ -37,6 +39,8 @@ RSpec.describe Taxman2023::YearInput do
       expect(year_input.translate).to eq(
         {
           b1: 1_00.to_d,
+          b1_pensionable: 1_00.to_d,
+          b1_insurable: 1_00.to_d,
           f5b_ytd: 2_00.to_d,
           p: 26,
           f1: 0,


### PR DESCRIPTION
Added three new required inputs: `b_insurable` (we already require `b_pensionable`) and `b1_insurable` `b1_pensionable`.  We also have two new  calculated inputs `pi_periodic` and `ie_periodic` which we need but can calculate from the other inputs.
We require these new inputs since I've re-written `K2` to use `pi` (pensionable income) and `ie` (insurable earnings) for the cpp and ei credits
How it was tested: new and existing specs.