### PR TITLE
BUG-8196 Cpp portion of K2 can't be negative

### DIFF
--- a/lib/taxman/taxman2023/k2_generic.rb
+++ b/lib/taxman/taxman2023/k2_generic.rb
@@ -60,7 +60,10 @@ module Taxman2023
     end
 
     def cpp_portion
-      ((pi_periodic + ((b_pensionable + b1_pensionable) / p)) - (Cpp::BASIC_EXEMPTION / p)) * Cpp::RATE
+      [
+        ((pi_periodic + ((b_pensionable + b1_pensionable) / p)) - (Cpp::BASIC_EXEMPTION / p)) * Cpp::RATE,
+        0
+      ].max
     end
 
     def ei_credit

--- a/spec/integration/taxman2023/bug_8196_spec.rb
+++ b/spec/integration/taxman2023/bug_8196_spec.rb
@@ -1,0 +1,74 @@
+# frozen_string_literal: true
+
+# rubocop:disable RSpec/FilePath
+RSpec.describe Taxman2023::Calculate do
+  let(:calculate) do
+    described_class.new(
+      period_input: p,
+      year_input: y,
+      td1_input: t,
+      cpp_input: c,
+      ei_input: e
+    ).call
+  end
+
+  let(:p) do
+    Taxman2023::PeriodInput.new(
+      taxable_periodic_income: 0,
+      taxable_non_periodic_income: 0,
+      province: "ab"
+    )
+  end
+
+  let(:y) do
+    Taxman2023::YearInput.new(
+      ytd_bonus: 0,
+      pay_periods: 24,
+      f5b_ytd: 0,
+      employer_ei_multiple: 1.4
+    )
+  end
+
+  let(:t) do
+    Taxman2023::Td1Input.new(
+      federal_personal_amount: nil,
+      provincial_personal_amount: nil,
+      additional_tax_deductions: 0,
+      federal_personal_amount_offset: -15_000,
+      provincial_personal_amount_offset: -21_003
+    )
+  end
+
+  let(:c) do
+    Taxman2023::CppInput.new(
+      pensionable_income_this_period: 0,
+      pensionable_non_periodic_income_this_period: 0,
+      ytd_contributions: 0,
+      contribution_months_this_year: 12
+    )
+  end
+
+  let(:e) do
+    Taxman2023::EiInput.new(
+      insurable_income_this_period: 0,
+      employees_ytd_contributions: 0
+    )
+  end
+
+  it "matches PDOC's federal tax" do
+    expect(calculate[:federal_tax]).to eq 0
+  end
+
+  it "matches PDOC's provincial tax" do
+    expect(calculate[:provincial_tax]).to eq 0
+  end
+
+  it "matches PDOC's CPP deduction" do
+    expect(calculate[:employee_cpp_contribution]).to eq 0
+  end
+
+  it "matches PDOC's EI calculation" do
+    expect(calculate[:employee_ei_contribution]).to eq 0
+  end
+end
+# rubocop:enable RSpec/FilePath

--- a/spec/taxman/taxman2023/calculate_spec.rb
+++ b/spec/taxman/taxman2023/calculate_spec.rb
@@ -231,7 +231,7 @@ RSpec.describe Taxman2023::Calculate do
 
     it "calculates the federal bonus tax owed" do
       expect(calculate.call).to match(
-        a_hash_including(federal_tax_on_bonus: 195.13)
+        a_hash_including(federal_tax_on_bonus: 202.56)
       )
     end
   end


### PR DESCRIPTION
If income is low enough, don't permit the cpp basic exemption to make the cpp portion of K2 negative