### PR TITLE
fix: DRY up province codes

### DIFF
--- a/lib/taxman.rb
+++ b/lib/taxman.rb
@@ -6,6 +6,7 @@ require_relative "taxman/taxman2021"
 require_relative "taxman/taxman2022"
 require_relative "taxman/taxman2023"
 
+# :nodoc:
 module Taxman
   class Error < StandardError; end
 

--- a/lib/taxman.rb
+++ b/lib/taxman.rb
@@ -13,17 +13,7 @@ module Taxman
 
   class UnsupportedProvince < StandardError; end
 
-  AB = "AB"
-  BC = "BC"
-  MB = "MB"
-  NB = "NB"
-  NL = "NL"
-  NS = "NS"
-  NT = "NT"
-  NU = "NU"
-  ON = "ON"
-  PE = "PE"
-  QC = "QC"
-  SK = "SK"
-  YT = "YT"
+  %w[AB BC MB NB NL NS NT NU ON PE QC SK YT].each do |province|
+    const_set(province, province)
+  end
 end


### PR DESCRIPTION
DRY up constants for province codes; would have liked to use `enum` but plain ruby does not have one 😉 