### PR TITLE
rubocop cleanup

### DIFF
--- a/spec/integration/taxman2023/demo_test_spec.rb
+++ b/spec/integration/taxman2023/demo_test_spec.rb
@@ -76,4 +76,4 @@ RSpec.describe Taxman2023::Calculate do
     expect(calculate[:provincial_tax_on_bonus]).to eq 566.25
   end
 end
-# rubocop:enable RSpec/FilePath, RSpec/MultipleMemoizedHelpers
+# rubocop:enable RSpec/FilePath

--- a/spec/integration/taxman2023/pay_4440_spec.rb
+++ b/spec/integration/taxman2023/pay_4440_spec.rb
@@ -121,4 +121,4 @@ RSpec.describe Taxman2023::Calculate do
     end
   end
 end
-# rubocop:enable RSpec/FilePath, RSpec/MultipleMemoizedHelpers
+# rubocop:enable RSpec/FilePath

--- a/spec/integration/taxman2023/pay_447_spec.rb
+++ b/spec/integration/taxman2023/pay_447_spec.rb
@@ -77,4 +77,4 @@ RSpec.describe Taxman2023::Calculate do
     expect(calculate[:employee_ei_contribution]).to eq 39.12
   end
 end
-# rubocop:enable RSpec/FilePath, RSpec/MultipleMemoizedHelpers
+# rubocop:enable RSpec/FilePath

--- a/spec/integration/taxman2023/test10_spec.rb
+++ b/spec/integration/taxman2023/test10_spec.rb
@@ -69,4 +69,4 @@ RSpec.describe Taxman2023::Calculate do
     expect(calculate[:employee_ei_contribution]).to eq 0
   end
 end
-# rubocop:enable RSpec/FilePath, RSpec/MultipleMemoizedHelpers
+# rubocop:enable RSpec/FilePath

--- a/spec/integration/taxman2023/test11_spec.rb
+++ b/spec/integration/taxman2023/test11_spec.rb
@@ -69,4 +69,4 @@ RSpec.describe Taxman2023::Calculate do
     expect(calculate[:employee_ei_contribution]).to eq 0
   end
 end
-# rubocop:enable RSpec/FilePath, RSpec/MultipleMemoizedHelpers
+# rubocop:enable RSpec/FilePath

--- a/spec/integration/taxman2023/test12_spec.rb
+++ b/spec/integration/taxman2023/test12_spec.rb
@@ -73,4 +73,4 @@ RSpec.describe Taxman2023::Calculate do
     expect(calculate[:employee_ei_contribution]).to eq 0
   end
 end
-# rubocop:enable RSpec/FilePath, RSpec/MultipleMemoizedHelpers
+# rubocop:enable RSpec/FilePath

--- a/spec/integration/taxman2023/test13_spec.rb
+++ b/spec/integration/taxman2023/test13_spec.rb
@@ -79,4 +79,4 @@ RSpec.describe Taxman2023::Calculate do
     expect(calculate[:employee_ei_contribution]).to eq 172.85
   end
 end
-# rubocop:enable RSpec/FilePath, RSpec/MultipleMemoizedHelpers
+# rubocop:enable RSpec/FilePath

--- a/spec/integration/taxman2023/test14_spec.rb
+++ b/spec/integration/taxman2023/test14_spec.rb
@@ -79,4 +79,4 @@ RSpec.describe Taxman2023::Calculate do
     expect(calculate[:employee_ei_contribution]).to eq 8.28
   end
 end
-# rubocop:enable RSpec/FilePath, RSpec/MultipleMemoizedHelpers
+# rubocop:enable RSpec/FilePath

--- a/spec/integration/taxman2023/test15_spec.rb
+++ b/spec/integration/taxman2023/test15_spec.rb
@@ -79,4 +79,4 @@ RSpec.describe Taxman2023::Calculate do
     expect(calculate[:employee_ei_contribution]).to eq 86.39
   end
 end
-# rubocop:enable RSpec/FilePath, RSpec/MultipleMemoizedHelpers
+# rubocop:enable RSpec/FilePath

--- a/spec/integration/taxman2023/test16_spec.rb
+++ b/spec/integration/taxman2023/test16_spec.rb
@@ -78,4 +78,4 @@ RSpec.describe Taxman2023::Calculate do
     expect(calculate[:employee_ei_contribution]).to eq 47.27
   end
 end
-# rubocop:enable RSpec/FilePath, RSpec/MultipleMemoizedHelpers
+# rubocop:enable RSpec/FilePath

--- a/spec/integration/taxman2023/test17_spec.rb
+++ b/spec/integration/taxman2023/test17_spec.rb
@@ -83,4 +83,4 @@ RSpec.describe Taxman2023::Calculate do
     expect(calculate[:f5b]).to be_within(1).of 541_75
   end
 end
-# rubocop:enable RSpec/FilePath, RSpec/MultipleMemoizedHelpers
+# rubocop:enable RSpec/FilePath

--- a/spec/integration/taxman2023/test18_spec.rb
+++ b/spec/integration/taxman2023/test18_spec.rb
@@ -78,4 +78,4 @@ RSpec.describe Taxman2023::Calculate do
     expect(calculate[:employee_ei_contribution]).to eq 19.56
   end
 end
-# rubocop:enable RSpec/FilePath, RSpec/MultipleMemoizedHelpers
+# rubocop:enable RSpec/FilePath

--- a/spec/integration/taxman2023/test19_spec.rb
+++ b/spec/integration/taxman2023/test19_spec.rb
@@ -78,4 +78,4 @@ RSpec.describe Taxman2023::Calculate do
     expect(calculate[:employee_ei_contribution]).to eq 107.91
   end
 end
-# rubocop:enable RSpec/FilePath, RSpec/MultipleMemoizedHelpers
+# rubocop:enable RSpec/FilePath

--- a/spec/integration/taxman2023/test1_spec.rb
+++ b/spec/integration/taxman2023/test1_spec.rb
@@ -68,4 +68,4 @@ RSpec.describe Taxman2023::Calculate do
     expect(calculate[:employee_ei_contribution]).to eq 33.90
   end
 end
-# rubocop:enable RSpec/FilePath, RSpec/MultipleMemoizedHelpers
+# rubocop:enable RSpec/FilePath

--- a/spec/integration/taxman2023/test20_spec.rb
+++ b/spec/integration/taxman2023/test20_spec.rb
@@ -78,4 +78,4 @@ RSpec.describe Taxman2023::Calculate do
     expect(calculate[:employee_ei_contribution]).to eq 0
   end
 end
-# rubocop:enable RSpec/FilePath, RSpec/MultipleMemoizedHelpers
+# rubocop:enable RSpec/FilePath

--- a/spec/integration/taxman2023/test21_spec.rb
+++ b/spec/integration/taxman2023/test21_spec.rb
@@ -78,4 +78,4 @@ RSpec.describe Taxman2023::Calculate do
     expect(calculate[:employee_ei_contribution]).to eq 73.37
   end
 end
-# rubocop:enable RSpec/FilePath, RSpec/MultipleMemoizedHelpers
+# rubocop:enable RSpec/FilePath

--- a/spec/integration/taxman2023/test22_spec.rb
+++ b/spec/integration/taxman2023/test22_spec.rb
@@ -78,4 +78,4 @@ RSpec.describe Taxman2023::Calculate do
     expect(calculate[:employee_ei_contribution]).to eq 17.40
   end
 end
-# rubocop:enable RSpec/FilePath, RSpec/MultipleMemoizedHelpers
+# rubocop:enable RSpec/FilePath

--- a/spec/integration/taxman2023/test23_spec.rb
+++ b/spec/integration/taxman2023/test23_spec.rb
@@ -78,4 +78,4 @@ RSpec.describe Taxman2023::Calculate do
     expect(calculate[:employee_ei_contribution]).to eq 17.40
   end
 end
-# rubocop:enable RSpec/FilePath, RSpec/MultipleMemoizedHelpers
+# rubocop:enable RSpec/FilePath

--- a/spec/integration/taxman2023/test2_spec.rb
+++ b/spec/integration/taxman2023/test2_spec.rb
@@ -68,4 +68,4 @@ RSpec.describe Taxman2023::Calculate do
     expect(calculate[:employee_ei_contribution]).to eq 51.75
   end
 end
-# rubocop:enable RSpec/FilePath, RSpec/MultipleMemoizedHelpers
+# rubocop:enable RSpec/FilePath

--- a/spec/integration/taxman2023/test3_spec.rb
+++ b/spec/integration/taxman2023/test3_spec.rb
@@ -70,4 +70,4 @@ RSpec.describe Taxman2023::Calculate do
     expect(calculate[:employee_ei_contribution]).to eq 65.20
   end
 end
-# rubocop:enable RSpec/FilePath, RSpec/MultipleMemoizedHelpers
+# rubocop:enable RSpec/FilePath

--- a/spec/integration/taxman2023/test4_spec.rb
+++ b/spec/integration/taxman2023/test4_spec.rb
@@ -69,4 +69,4 @@ RSpec.describe Taxman2023::Calculate do
     expect(calculate[:employee_ei_contribution]).to eq 81.50
   end
 end
-# rubocop:enable RSpec/FilePath, RSpec/MultipleMemoizedHelpers
+# rubocop:enable RSpec/FilePath

--- a/spec/integration/taxman2023/test5_spec.rb
+++ b/spec/integration/taxman2023/test5_spec.rb
@@ -69,4 +69,4 @@ RSpec.describe Taxman2023::Calculate do
     expect(calculate[:employee_ei_contribution]).to eq 0
   end
 end
-# rubocop:enable RSpec/FilePath, RSpec/MultipleMemoizedHelpers
+# rubocop:enable RSpec/FilePath

--- a/spec/integration/taxman2023/test6_spec.rb
+++ b/spec/integration/taxman2023/test6_spec.rb
@@ -69,4 +69,4 @@ RSpec.describe Taxman2023::Calculate do
     expect(calculate[:employee_ei_contribution]).to eq 0
   end
 end
-# rubocop:enable RSpec/FilePath, RSpec/MultipleMemoizedHelpers
+# rubocop:enable RSpec/FilePath

--- a/spec/integration/taxman2023/test7_spec.rb
+++ b/spec/integration/taxman2023/test7_spec.rb
@@ -69,4 +69,4 @@ RSpec.describe Taxman2023::Calculate do
     expect(calculate[:employee_ei_contribution]).to eq 0
   end
 end
-# rubocop:enable RSpec/FilePath, RSpec/MultipleMemoizedHelpers
+# rubocop:enable RSpec/FilePath

--- a/spec/integration/taxman2023/test8_spec.rb
+++ b/spec/integration/taxman2023/test8_spec.rb
@@ -69,4 +69,4 @@ RSpec.describe Taxman2023::Calculate do
     expect(calculate[:employee_ei_contribution]).to eq 0
   end
 end
-# rubocop:enable RSpec/FilePath, RSpec/MultipleMemoizedHelpers
+# rubocop:enable RSpec/FilePath

--- a/spec/integration/taxman2023/test9_spec.rb
+++ b/spec/integration/taxman2023/test9_spec.rb
@@ -69,4 +69,4 @@ RSpec.describe Taxman2023::Calculate do
     expect(calculate[:employee_ei_contribution]).to eq 0
   end
 end
-# rubocop:enable RSpec/FilePath, RSpec/MultipleMemoizedHelpers
+# rubocop:enable RSpec/FilePath

--- a/spec/taxman/taxman2023/a_bonus_spec.rb
+++ b/spec/taxman/taxman2023/a_bonus_spec.rb
@@ -89,4 +89,3 @@ RSpec.describe Taxman2023::ABonus do
     end
   end
 end
-# rubocop:enable RSpec/MultipleMemoizedHelpers

--- a/spec/taxman/taxman2023/a_spec.rb
+++ b/spec/taxman/taxman2023/a_spec.rb
@@ -49,4 +49,3 @@ RSpec.describe Taxman2023::A do
     end
   end
 end
-# rubocop:enable RSpec/MultipleMemoizedHelpers

--- a/spec/taxman/taxman2023/calculate_spec.rb
+++ b/spec/taxman/taxman2023/calculate_spec.rb
@@ -249,4 +249,3 @@ RSpec.describe Taxman2023::Calculate do
     end
   end
 end
-# rubocop:enable RSpec/MultipleMemoizedHelpers

--- a/spec/taxman/taxman2023/k2_generic_spec.rb
+++ b/spec/taxman/taxman2023/k2_generic_spec.rb
@@ -69,4 +69,3 @@ RSpec.describe Taxman2023::K2Generic do
     end
   end
 end
-# rubocop:enable RSpec/MultipleMemoizedHelpers

--- a/spec/taxman/taxman2023/nl/t4_spec.rb
+++ b/spec/taxman/taxman2023/nl/t4_spec.rb
@@ -62,4 +62,3 @@ RSpec.describe Taxman2023::Nl::T4 do
     end
   end
 end
-# rubocop:enable RSpec/MultipleMemoizedHelpers

--- a/spec/taxman/taxman2023/on/t4_spec.rb
+++ b/spec/taxman/taxman2023/on/t4_spec.rb
@@ -62,4 +62,3 @@ RSpec.describe Taxman2023::On::T4 do
     end
   end
 end
-# rubocop:enable RSpec/MultipleMemoizedHelpers

--- a/spec/taxman/taxman2023/personal_tax_deductions_input_spec.rb
+++ b/spec/taxman/taxman2023/personal_tax_deductions_input_spec.rb
@@ -71,4 +71,3 @@ RSpec.describe Taxman2023::PersonalTaxDeductionsInput do
   end
 end
 # rubocop:enable RSpec/ExampleLength
-# rubocop:enable RSpec/MultipleMemoizedHelpers


### PR DESCRIPTION
#51 disabled `MultipleMemoizedHelpers` globally and removed per-file disable statements, but did not remove per-file re-enabling