### PR TITLE
fix: linting cleanup

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -23,5 +23,20 @@ Style/StringLiteralsInInterpolation:
 RSpec/MultipleMemoizedHelpers:
   Enabled: false
 
+Metrics/AbcSize:
+  Enabled: false
+
+Metrics/ParameterLists:
+  Enabled: false
+
+RSpec/FilePath:
+  SpecSuffixOnly: true
+
 Layout/LineLength:
   Max: 120
+
+Metrics/MethodLength:
+  Max: 40
+
+RSpec/ExampleLength:
+  Max: 20

--- a/lib/taxman/taxman2023/a.rb
+++ b/lib/taxman/taxman2023/a.rb
@@ -16,7 +16,6 @@ module Taxman2023
       %i[p i f f2 f5a u1 hd f1]
     end
 
-    # rubocop:disable Metrics/ParameterLists
     def initialize(
       p:,
       i:,
@@ -36,7 +35,6 @@ module Taxman2023
       @hd = hd.to_d
       @f1 = f1.to_d
     end
-    # rubocop:enable Metrics/ParameterLists
 
     def amount
       a = (p * (i - f - f2 - f5a - u1)) - hd - f1

--- a/lib/taxman/taxman2023/bonus_tax_calculator.rb
+++ b/lib/taxman/taxman2023/bonus_tax_calculator.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-# rubocop:disable Metrics/MethodLength, Metrics/AbcSize
 module Taxman2023
   # Calculates the federal and provincial bonus taxes
   class BonusTaxCalculator
@@ -98,4 +97,3 @@ module Taxman2023
     end
   end
 end
-# rubocop:enable Metrics/MethodLength, Metrics/AbcSize

--- a/lib/taxman/taxman2023/c.rb
+++ b/lib/taxman/taxman2023/c.rb
@@ -5,7 +5,6 @@ module Taxman2023
   class C
     attr_reader :pi, :p, :pm, :d, :dq, :b_pensionable
 
-    # rubocop:disable Metrics/ParameterLists
     def initialize(pi:, p:, pm:, d:, b_pensionable:, dq:)
       @pi = pi.to_d
       @p = p.to_d
@@ -14,7 +13,6 @@ module Taxman2023
       @dq = dq.to_d
       @b_pensionable = b_pensionable.to_d
     end
-    # rubocop:enable Metrics/ParameterLists
 
     def self.params
       %i[pi p pm d b_pensionable dq]

--- a/lib/taxman/taxman2023/calculate.rb
+++ b/lib/taxman/taxman2023/calculate.rb
@@ -1,13 +1,11 @@
 # frozen_string_literal: true
 
-# rubocop:disable Metrics/AbcSize, Metrics/MethodLength
 module Taxman2023
   # The main entry point to the tax calculator
   class Calculate
     attr_reader :period_input, :year_input, :personal_tax_input, :pension_input,
                 :qpip_input, :ei_input, :context
 
-    # rubocop:disable Metrics/ParameterLists
     def initialize(
       period_input:,
       year_input:,
@@ -23,7 +21,6 @@ module Taxman2023
       @qpip_input = qpip_input
       @ei_input = ei_input
     end
-    # rubocop:enable Metrics/ParameterLists
 
     def call
       @context = {}
@@ -66,4 +63,3 @@ module Taxman2023
     end
   end
 end
-# rubocop:enable Metrics/AbcSize, Metrics/MethodLength

--- a/lib/taxman/taxman2023/k2_generic.rb
+++ b/lib/taxman/taxman2023/k2_generic.rb
@@ -13,7 +13,6 @@ module Taxman2023
                 :b1_insurable, # Insurable bonus YTD
                 :p # Number of periods
 
-    # rubocop:disable Metrics/ParameterLists, Metrics/MethodLength
     def initialize(
       pi:,
       pi_periodic:,
@@ -42,7 +41,6 @@ module Taxman2023
       @d = d
       @d1 = d1
     end
-    # rubocop:enable Metrics/ParameterLists, Metrics/MethodLength
 
     def self.params
       %i[pi pi_periodic b_pensionable b1_pensionable ie ie_periodic b_insurable b1_insurable p d d1]

--- a/lib/taxman/taxman2023/on/t2.rb
+++ b/lib/taxman/taxman2023/on/t2.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-# rubocop:disable Metrics/AbcSize, Metrics/MethodLength, Style/ComparableClamp
 module Taxman2023
   module On
     # This calculates the T2 factor for ontario
@@ -32,7 +31,8 @@ module Taxman2023
       end
 
       def s
-        [[t4 + v1, (2 * (s2 + 0)) - (t4 + v1)].min, 0].max.to_d
+        s = [t4 + v1, (2 * (s2 + 0)) - (t4 + v1)].min
+        [s, 0].max.to_d
       end
 
       def s2
@@ -41,4 +41,3 @@ module Taxman2023
     end
   end
 end
-# rubocop:enable Metrics/AbcSize, Metrics/MethodLength, Style/ComparableClamp

--- a/lib/taxman/taxman2023/pension_input.rb
+++ b/lib/taxman/taxman2023/pension_input.rb
@@ -15,7 +15,6 @@ module Taxman2023
       @contribution_months_this_year = contribution_months_this_year
     end
 
-    # rubocop:disable Metrics/MethodLength
     def translate
       pensionable_income_this_period = (@pensionable_income_this_period * 100).to_d
       pensionable_non_periodic_income_this_period = (@pensionable_non_periodic_income_this_period * 100).to_d
@@ -43,6 +42,5 @@ module Taxman2023
         pm: @contribution_months_this_year
       }
     end
-    # rubocop:enable Metrics/MethodLength
   end
 end

--- a/lib/taxman/taxman2023/period_input.rb
+++ b/lib/taxman/taxman2023/period_input.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-# rubocop:disable Metrics/ParameterLists
 module Taxman2023
   # This input collects the factors specific to the current pay period
   class PeriodInput
@@ -26,7 +25,6 @@ module Taxman2023
       @qc_b2 = taxable_non_periodic_income
     end
 
-    # rubocop:disable Metrics/MethodLength, Metrics/AbcSize
     def translate
       {
         i: (@i * 100).to_d,
@@ -42,7 +40,5 @@ module Taxman2023
         qc_b2: (@qc_b2 * 100).to_d
       }
     end
-    # rubocop:enable Metrics/MethodLength, Metrics/AbcSize
   end
 end
-# rubocop:enable Metrics/ParameterLists

--- a/lib/taxman/taxman2023/personal_tax_deductions_input.rb
+++ b/lib/taxman/taxman2023/personal_tax_deductions_input.rb
@@ -5,7 +5,6 @@ module Taxman2023
   class PersonalTaxDeductionsInput
     # If nil is passed for either of the personal amounts, we
     # will calculate them using the standard formula
-    # rubocop:disable Metrics/MethodLength,Metrics/ParameterLists
     def initialize(
       federal_personal_amount: nil,
       provincial_personal_amount: nil,
@@ -31,9 +30,7 @@ module Taxman2023
       @qc_j = tp_1015_line_19_deductions
       @qc_j1 = tp_1016_annual_deductions
     end
-    # rubocop:enable Metrics/MethodLength,Metrics/ParameterLists
 
-    # rubocop:disable Metrics/MethodLength,Metrics/AbcSize
     def translate
       {
         tc: tc,
@@ -53,7 +50,6 @@ module Taxman2023
         qc_l: (@qc_l * 100).to_d
       }
     end
-    # rubocop:enable Metrics/MethodLength,Metrics/AbcSize
 
     def tc
       @tc.nil? ? nil : (@tc * 100).to_d

--- a/lib/taxman/taxman2023/qc_i1.rb
+++ b/lib/taxman/taxman2023/qc_i1.rb
@@ -8,10 +8,8 @@ module Taxman2023
     end
     attr_reader(*params)
 
-    # rubocop:disable Metrics/AbcSize
     def amount
       [(qc_g1 - qc_f1 - qc_h1 - qc_csa1) + (qc_pr * (qc_g - f - qc_h2 - qc_csa)) - qc_j - qc_j1, 0].max
     end
-    # rubocop:enable Metrics/AbcSize
   end
 end

--- a/lib/taxman/taxman2023/qc_y.rb
+++ b/lib/taxman/taxman2023/qc_y.rb
@@ -15,7 +15,7 @@ module Taxman2023
     end
     attr_reader(*params)
 
-    def amount # rubocop:disable Metrics/AbcSize
+    def amount
       [(qc_t * qc_i) - qc_k - qc_k1 - (0.14 * qc_e) - (0.15 * p * qc_q) - (0.15 * p * qc_q1), 0].max
     end
 

--- a/lib/taxman/taxman2023/qc_y1_y2.rb
+++ b/lib/taxman/taxman2023/qc_y1_y2.rb
@@ -8,7 +8,7 @@ module Taxman2023
     end
     attr_reader(*params)
 
-    def amount # rubocop:disable Metrics/AbcSize
+    def amount
       [(qc_t * income_amounts) - qc_k - qc_k1 - (0.14 * qc_e) - (0.15 * p * qc_q) - (0.15 * p * qc_q1), 0].max
     end
 

--- a/lib/taxman/taxman2023/t3.rb
+++ b/lib/taxman/taxman2023/t3.rb
@@ -15,7 +15,6 @@ module Taxman2023
       BigDecimal("Infinity") => [0.330.to_d, 23_194_00.to_d]
     }.freeze
 
-    # rubocop:disable Metrics/ParameterLists
     def initialize(a:, hd:, k2:, tc: nil, k3: 0, tc_offset: 0)
       @a = a.to_d
       @hd = hd.to_d
@@ -24,7 +23,6 @@ module Taxman2023
       @tc = tc&.to_d
       @tc_offset = tc_offset&.to_d
     end
-    # rubocop:enable Metrics/ParameterLists
 
     def self.params
       %i[a hd k2 k3 tc tc_offset]

--- a/lib/taxman/taxman2023/t4_generic.rb
+++ b/lib/taxman/taxman2023/t4_generic.rb
@@ -8,7 +8,6 @@ module Taxman2023
                 :k2p,
                 :k3p
 
-    # rubocop:disable Metrics/ParameterLists
     def initialize(
       a:,
       hd:,
@@ -24,7 +23,6 @@ module Taxman2023
       @k2p = k2p.to_d # Tax credit for cpp contributions
       @k3p = k3p.to_d # Other non-refundable provincial tax credits
     end
-    # rubocop:enable Metrics/ParameterLists
 
     def self.params
       %i[a hd k2p k3p tcp tcp_offset]

--- a/lib/taxman/taxman2023/tax_calculator.rb
+++ b/lib/taxman/taxman2023/tax_calculator.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-# rubocop:disable Metrics/AbcSize, Metrics/MethodLength
 module Taxman2023
   # Calculate the federal and provincial taxes
   # Requires A, F5A, F5B and C to have already been set in context
@@ -141,4 +140,3 @@ module Taxman2023
     end
   end
 end
-# rubocop:enable Metrics/AbcSize, Metrics/MethodLength

--- a/lib/taxman/taxman2023/year_input.rb
+++ b/lib/taxman/taxman2023/year_input.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-# rubocop:disable Metrics/ParameterLists, Metrics/MethodLength
 module Taxman2023
   # This input collects the ytd and general inputs
   class YearInput
@@ -38,7 +37,6 @@ module Taxman2023
       @qc_csb1 = ytd_csb
     end
 
-    # rubocop:disable Metrics/AbcSize
     def translate
       {
         b1: (@b1 * 100).to_d,
@@ -58,7 +56,5 @@ module Taxman2023
         qc_csb1: (@qc_csb1 * 100).to_d
       }
     end
-    # rubocop:enable Metrics/AbcSize
   end
 end
-# rubocop:enable Metrics/ParameterLists, Metrics/MethodLength

--- a/spec/integration/taxman2023/bug_8143_spec.rb
+++ b/spec/integration/taxman2023/bug_8143_spec.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-# rubocop:disable RSpec/FilePath
 RSpec.describe Taxman2023::Calculate do
   # NOTE: EI EXEMPT ON PDOC
   let(:calculate) do
@@ -72,4 +71,3 @@ RSpec.describe Taxman2023::Calculate do
     expect(calculate[:employee_ei_contribution]).to eq 0
   end
 end
-# rubocop:enable RSpec/FilePath

--- a/spec/integration/taxman2023/bug_8196_spec.rb
+++ b/spec/integration/taxman2023/bug_8196_spec.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-# rubocop:disable RSpec/FilePath
 RSpec.describe Taxman2023::Calculate do
   let(:calculate) do
     described_class.new(
@@ -72,4 +71,3 @@ RSpec.describe Taxman2023::Calculate do
     expect(calculate[:employee_ei_contribution]).to eq 0
   end
 end
-# rubocop:enable RSpec/FilePath

--- a/spec/integration/taxman2023/demo_test_spec.rb
+++ b/spec/integration/taxman2023/demo_test_spec.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-# rubocop:disable RSpec/FilePath
 RSpec.describe Taxman2023::Calculate do
   let(:calculate) do
     described_class.new(
@@ -76,4 +75,3 @@ RSpec.describe Taxman2023::Calculate do
     expect(calculate[:provincial_tax_on_bonus]).to eq 566.25
   end
 end
-# rubocop:enable RSpec/FilePath

--- a/spec/integration/taxman2023/pay_4440_spec.rb
+++ b/spec/integration/taxman2023/pay_4440_spec.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-# rubocop:disable RSpec/FilePath
 RSpec.describe Taxman2023::Calculate do
   let(:calculate) do
     described_class.new(
@@ -121,4 +120,3 @@ RSpec.describe Taxman2023::Calculate do
     end
   end
 end
-# rubocop:enable RSpec/FilePath

--- a/spec/integration/taxman2023/pay_447_spec.rb
+++ b/spec/integration/taxman2023/pay_447_spec.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-# rubocop:disable RSpec/FilePath
 RSpec.describe Taxman2023::Calculate do
   let(:calculate) do
     described_class.new(
@@ -77,4 +76,3 @@ RSpec.describe Taxman2023::Calculate do
     expect(calculate[:employee_ei_contribution]).to eq 39.12
   end
 end
-# rubocop:enable RSpec/FilePath

--- a/spec/integration/taxman2023/test10_spec.rb
+++ b/spec/integration/taxman2023/test10_spec.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-# rubocop:disable RSpec/FilePath
 RSpec.describe Taxman2023::Calculate do
   let(:calculate) do
     described_class.new(
@@ -69,4 +68,3 @@ RSpec.describe Taxman2023::Calculate do
     expect(calculate[:employee_ei_contribution]).to eq 0
   end
 end
-# rubocop:enable RSpec/FilePath

--- a/spec/integration/taxman2023/test11_spec.rb
+++ b/spec/integration/taxman2023/test11_spec.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-# rubocop:disable RSpec/FilePath
 RSpec.describe Taxman2023::Calculate do
   let(:calculate) do
     described_class.new(
@@ -69,4 +68,3 @@ RSpec.describe Taxman2023::Calculate do
     expect(calculate[:employee_ei_contribution]).to eq 0
   end
 end
-# rubocop:enable RSpec/FilePath

--- a/spec/integration/taxman2023/test12_spec.rb
+++ b/spec/integration/taxman2023/test12_spec.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-# rubocop:disable RSpec/FilePath
 RSpec.describe Taxman2023::Calculate do
   let(:calculate) do
     described_class.new(
@@ -73,4 +72,3 @@ RSpec.describe Taxman2023::Calculate do
     expect(calculate[:employee_ei_contribution]).to eq 0
   end
 end
-# rubocop:enable RSpec/FilePath

--- a/spec/integration/taxman2023/test13_spec.rb
+++ b/spec/integration/taxman2023/test13_spec.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-# rubocop:disable RSpec/FilePath
 RSpec.describe Taxman2023::Calculate do
   let(:calculate) do
     described_class.new(
@@ -79,4 +78,3 @@ RSpec.describe Taxman2023::Calculate do
     expect(calculate[:employee_ei_contribution]).to eq 172.85
   end
 end
-# rubocop:enable RSpec/FilePath

--- a/spec/integration/taxman2023/test14_spec.rb
+++ b/spec/integration/taxman2023/test14_spec.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-# rubocop:disable RSpec/FilePath
 RSpec.describe Taxman2023::Calculate do
   let(:calculate) do
     described_class.new(
@@ -79,4 +78,3 @@ RSpec.describe Taxman2023::Calculate do
     expect(calculate[:employee_ei_contribution]).to eq 8.28
   end
 end
-# rubocop:enable RSpec/FilePath

--- a/spec/integration/taxman2023/test15_spec.rb
+++ b/spec/integration/taxman2023/test15_spec.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-# rubocop:disable RSpec/FilePath
 RSpec.describe Taxman2023::Calculate do
   let(:calculate) do
     described_class.new(
@@ -79,4 +78,3 @@ RSpec.describe Taxman2023::Calculate do
     expect(calculate[:employee_ei_contribution]).to eq 86.39
   end
 end
-# rubocop:enable RSpec/FilePath

--- a/spec/integration/taxman2023/test16_spec.rb
+++ b/spec/integration/taxman2023/test16_spec.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-# rubocop:disable RSpec/FilePath
 RSpec.describe Taxman2023::Calculate do
   let(:calculate) do
     described_class.new(
@@ -78,4 +77,3 @@ RSpec.describe Taxman2023::Calculate do
     expect(calculate[:employee_ei_contribution]).to eq 47.27
   end
 end
-# rubocop:enable RSpec/FilePath

--- a/spec/integration/taxman2023/test17_spec.rb
+++ b/spec/integration/taxman2023/test17_spec.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-# rubocop:disable RSpec/FilePath
 RSpec.describe Taxman2023::Calculate do
   let(:calculate) do
     described_class.new(
@@ -83,4 +82,3 @@ RSpec.describe Taxman2023::Calculate do
     expect(calculate[:f5b]).to be_within(1).of 541_75
   end
 end
-# rubocop:enable RSpec/FilePath

--- a/spec/integration/taxman2023/test18_spec.rb
+++ b/spec/integration/taxman2023/test18_spec.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-# rubocop:disable RSpec/FilePath
 RSpec.describe Taxman2023::Calculate do
   let(:calculate) do
     described_class.new(
@@ -78,4 +77,3 @@ RSpec.describe Taxman2023::Calculate do
     expect(calculate[:employee_ei_contribution]).to eq 19.56
   end
 end
-# rubocop:enable RSpec/FilePath

--- a/spec/integration/taxman2023/test19_spec.rb
+++ b/spec/integration/taxman2023/test19_spec.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-# rubocop:disable RSpec/FilePath
 RSpec.describe Taxman2023::Calculate do
   let(:calculate) do
     described_class.new(
@@ -78,4 +77,3 @@ RSpec.describe Taxman2023::Calculate do
     expect(calculate[:employee_ei_contribution]).to eq 107.91
   end
 end
-# rubocop:enable RSpec/FilePath

--- a/spec/integration/taxman2023/test1_spec.rb
+++ b/spec/integration/taxman2023/test1_spec.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-# rubocop:disable RSpec/FilePath
 RSpec.describe Taxman2023::Calculate do
   let(:calculate) do
     described_class.new(
@@ -68,4 +67,3 @@ RSpec.describe Taxman2023::Calculate do
     expect(calculate[:employee_ei_contribution]).to eq 33.90
   end
 end
-# rubocop:enable RSpec/FilePath

--- a/spec/integration/taxman2023/test20_spec.rb
+++ b/spec/integration/taxman2023/test20_spec.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-# rubocop:disable RSpec/FilePath
 RSpec.describe Taxman2023::Calculate do
   let(:calculate) do
     described_class.new(
@@ -78,4 +77,3 @@ RSpec.describe Taxman2023::Calculate do
     expect(calculate[:employee_ei_contribution]).to eq 0
   end
 end
-# rubocop:enable RSpec/FilePath

--- a/spec/integration/taxman2023/test21_spec.rb
+++ b/spec/integration/taxman2023/test21_spec.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-# rubocop:disable RSpec/FilePath
 RSpec.describe Taxman2023::Calculate do
   let(:calculate) do
     described_class.new(
@@ -78,4 +77,3 @@ RSpec.describe Taxman2023::Calculate do
     expect(calculate[:employee_ei_contribution]).to eq 73.37
   end
 end
-# rubocop:enable RSpec/FilePath

--- a/spec/integration/taxman2023/test22_spec.rb
+++ b/spec/integration/taxman2023/test22_spec.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-# rubocop:disable RSpec/FilePath
 RSpec.describe Taxman2023::Calculate do
   let(:calculate) do
     described_class.new(
@@ -78,4 +77,3 @@ RSpec.describe Taxman2023::Calculate do
     expect(calculate[:employee_ei_contribution]).to eq 17.40
   end
 end
-# rubocop:enable RSpec/FilePath

--- a/spec/integration/taxman2023/test23_spec.rb
+++ b/spec/integration/taxman2023/test23_spec.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-# rubocop:disable RSpec/FilePath
 RSpec.describe Taxman2023::Calculate do
   let(:calculate) do
     described_class.new(
@@ -78,4 +77,3 @@ RSpec.describe Taxman2023::Calculate do
     expect(calculate[:employee_ei_contribution]).to eq 17.40
   end
 end
-# rubocop:enable RSpec/FilePath

--- a/spec/integration/taxman2023/test24_spec.rb
+++ b/spec/integration/taxman2023/test24_spec.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-# rubocop:disable RSpec/FilePath
 RSpec.describe Taxman2023::Calculate do
   let(:calculate) do
     described_class.new(
@@ -72,4 +71,3 @@ RSpec.describe Taxman2023::Calculate do
     expect(calculate[:employee_ei_contribution]).to eq 0
   end
 end
-# rubocop:enable RSpec/FilePath

--- a/spec/integration/taxman2023/test2_spec.rb
+++ b/spec/integration/taxman2023/test2_spec.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-# rubocop:disable RSpec/FilePath
 RSpec.describe Taxman2023::Calculate do
   let(:calculate) do
     described_class.new(
@@ -68,4 +67,3 @@ RSpec.describe Taxman2023::Calculate do
     expect(calculate[:employee_ei_contribution]).to eq 51.75
   end
 end
-# rubocop:enable RSpec/FilePath

--- a/spec/integration/taxman2023/test3_spec.rb
+++ b/spec/integration/taxman2023/test3_spec.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-# rubocop:disable RSpec/FilePath
 RSpec.describe Taxman2023::Calculate do
   let(:calculate) do
     described_class.new(
@@ -70,4 +69,3 @@ RSpec.describe Taxman2023::Calculate do
     expect(calculate[:employee_ei_contribution]).to eq 65.20
   end
 end
-# rubocop:enable RSpec/FilePath

--- a/spec/integration/taxman2023/test4_spec.rb
+++ b/spec/integration/taxman2023/test4_spec.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-# rubocop:disable RSpec/FilePath
 RSpec.describe Taxman2023::Calculate do
   let(:calculate) do
     described_class.new(
@@ -69,4 +68,3 @@ RSpec.describe Taxman2023::Calculate do
     expect(calculate[:employee_ei_contribution]).to eq 81.50
   end
 end
-# rubocop:enable RSpec/FilePath

--- a/spec/integration/taxman2023/test5_spec.rb
+++ b/spec/integration/taxman2023/test5_spec.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-# rubocop:disable RSpec/FilePath
 RSpec.describe Taxman2023::Calculate do
   let(:calculate) do
     described_class.new(
@@ -69,4 +68,3 @@ RSpec.describe Taxman2023::Calculate do
     expect(calculate[:employee_ei_contribution]).to eq 0
   end
 end
-# rubocop:enable RSpec/FilePath

--- a/spec/integration/taxman2023/test6_spec.rb
+++ b/spec/integration/taxman2023/test6_spec.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-# rubocop:disable RSpec/FilePath
 RSpec.describe Taxman2023::Calculate do
   let(:calculate) do
     described_class.new(
@@ -69,4 +68,3 @@ RSpec.describe Taxman2023::Calculate do
     expect(calculate[:employee_ei_contribution]).to eq 0
   end
 end
-# rubocop:enable RSpec/FilePath

--- a/spec/integration/taxman2023/test7_spec.rb
+++ b/spec/integration/taxman2023/test7_spec.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-# rubocop:disable RSpec/FilePath
 RSpec.describe Taxman2023::Calculate do
   let(:calculate) do
     described_class.new(
@@ -69,4 +68,3 @@ RSpec.describe Taxman2023::Calculate do
     expect(calculate[:employee_ei_contribution]).to eq 0
   end
 end
-# rubocop:enable RSpec/FilePath

--- a/spec/integration/taxman2023/test8_spec.rb
+++ b/spec/integration/taxman2023/test8_spec.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-# rubocop:disable RSpec/FilePath
 RSpec.describe Taxman2023::Calculate do
   let(:calculate) do
     described_class.new(
@@ -69,4 +68,3 @@ RSpec.describe Taxman2023::Calculate do
     expect(calculate[:employee_ei_contribution]).to eq 0
   end
 end
-# rubocop:enable RSpec/FilePath

--- a/spec/integration/taxman2023/test9_spec.rb
+++ b/spec/integration/taxman2023/test9_spec.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-# rubocop:disable RSpec/FilePath
 RSpec.describe Taxman2023::Calculate do
   let(:calculate) do
     described_class.new(
@@ -69,4 +68,3 @@ RSpec.describe Taxman2023::Calculate do
     expect(calculate[:employee_ei_contribution]).to eq 0
   end
 end
-# rubocop:enable RSpec/FilePath

--- a/spec/taxman/taxman2023/period_input_spec.rb
+++ b/spec/taxman/taxman2023/period_input_spec.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-# rubocop:disable RSpec/ExampleLength
 RSpec.describe Taxman2023::PeriodInput do
   let(:period_input) do
     described_class.new(
@@ -61,4 +60,3 @@ RSpec.describe Taxman2023::PeriodInput do
     end
   end
 end
-# rubocop:enable RSpec/ExampleLength

--- a/spec/taxman/taxman2023/personal_tax_deductions_input_spec.rb
+++ b/spec/taxman/taxman2023/personal_tax_deductions_input_spec.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-# rubocop:disable RSpec/ExampleLength
 RSpec.describe Taxman2023::PersonalTaxDeductionsInput do
   let(:deductions_input) do
     described_class.new(
@@ -70,4 +69,3 @@ RSpec.describe Taxman2023::PersonalTaxDeductionsInput do
     end
   end
 end
-# rubocop:enable RSpec/ExampleLength

--- a/spec/taxman/taxman2023/year_input_spec.rb
+++ b/spec/taxman/taxman2023/year_input_spec.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-# rubocop:disable RSpec/ExampleLength
 RSpec.describe Taxman2023::YearInput do
   let(:year_input) do
     described_class.new(
@@ -68,4 +67,3 @@ RSpec.describe Taxman2023::YearInput do
     end
   end
 end
-# rubocop:enable RSpec/ExampleLength


### PR DESCRIPTION
the code is littered with `rubocop:disable` statements and they're mostly the same ones.  let's just be honest about the code in this repo and have the yml reflect how we're coding.  this removes all `rubocop:disable` statements, leaving `.rubocop.yml` as the one place to configure rubocop.

<img width="128" alt="image" src="https://github.com/Humi-HR/taxman/assets/134647356/07cf1402-5666-45f7-a7a6-c126b75c5094">
