### PR TITLE
fix: Error on bad remaining PP type

### DIFF
--- a/lib/taxman/taxman2023/period_input.rb
+++ b/lib/taxman/taxman2023/period_input.rb
@@ -43,7 +43,7 @@ module Taxman2023
         qc_d: (@qc_d * 100).to_d,
         qc_b2: (@qc_b2 * 100).to_d,
         moved_in_or_out_qc: @moved_in_or_out_qc,
-        qc_pr: @qc_pr
+        qc_pr: @qc_pr.to_d
       }
     end
   end


### PR DESCRIPTION
The type needs to be cast to a BigDecimal for the application to run properly.

Tested by casting on the application side.
