### PR TITLE
PAY-0: fix erroneous YT K4P rate

### DIFF
--- a/lib/taxman/taxman2024/yt/t4.rb
+++ b/lib/taxman/taxman2024/yt/t4.rb
@@ -6,7 +6,7 @@ module Taxman2024
     class T4 < T4Generic
       LOWEST_RATE = 0.0640.to_d
       CEA = 1_433_00.to_d
-      K4P_RATE = BigDecimal("0.047")
+      K4P_RATE = LOWEST_RATE
 
       RATES_AND_CONSTANTS = {
         55_867_00.to_d => [LOWEST_RATE, 0.0.to_d],

--- a/spec/taxman/taxman2024/yt/t4_spec.rb
+++ b/spec/taxman/taxman2024/yt/t4_spec.rb
@@ -7,16 +7,16 @@ RSpec.describe Taxman2024::Yt::T4 do
     context "when a is less than CEA" do
       let(:a) { 1_000_00 }
 
-      it "equals 4.7% times a" do
-        expect(t4.k4p).to eq 0.047 * a
+      it "equals 6.4% times a" do
+        expect(t4.k4p).to eq 0.064 * a
       end
     end
 
     context "when a is greater than CEA" do
       let(:a) { 2_000_00 }
 
-      it "equals 4.7% times CEA" do
-        expect(t4.k4p).to eq 0.047 * described_class::CEA
+      it "equals 6.4% times CEA" do
+        expect(t4.k4p).to eq 0.064 * described_class::CEA
       end
     end
   end


### PR DESCRIPTION
a110041 erroneously changed YT's K4P rate; per [T4127](https://www.canada.ca/en/revenue-agency/services/forms-publications/payroll/t4127-payroll-deductions-formulas/t4127-jan/t4127-jan-payroll-deductions-formulas-computer-programs.html) it should be YT's lowest tax rate