### PR TITLE
PAY-1486 skip 2024 integration tests

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -13,6 +13,8 @@ RSpec.configure do |config|
     c.syntax = :expect
   end
 
+  config.exclude_pattern = "spec/integration/taxman2024/*"
+
   Taxman2024::Calculate.enable
 end
 


### PR DESCRIPTION
2024 integration tests are currently just a copy of 2023 tests and hence all fail.  skip for now until they have been updated for 2024 output.