### PR TITLE
support for 2024 tax year

### DIFF
--- a/lib/taxman/taxman2024/ab/t4.rb
+++ b/lib/taxman/taxman2024/ab/t4.rb
@@ -5,14 +5,14 @@ module Taxman2024
     # Calculates the annualized provincial tax
     class T4 < T4Generic
       LOWEST_RATE = 0.1.to_d
-      DEFAULT_TD1 = 21_003_00.to_d
+      DEFAULT_TD1 = 21_885_00.to_d
 
       RATES_AND_CONSTANTS = {
-        142_292_00.to_d => [LOWEST_RATE, 0.0.to_d],
-        170_751_00.to_d => [0.12, 2_846_00.to_d],
-        227_668_00.to_d => [0.13, 4_553_00.to_d],
-        341_502_00.to_d => [0.14, 6_830_00.to_d],
-        BigDecimal("Infinity") => [0.15, 10_245_00.to_d]
+        148_289_00.to_d => [LOWEST_RATE, 0.0.to_d],
+        177_922_00.to_d => [0.12, 2_965_00.to_d],
+        237_230_00.to_d => [0.13, 4_745_00.to_d],
+        355_845_00.to_d => [0.14, 7_117_00.to_d],
+        BigDecimal("Infinity") => [0.15, 10_675_00.to_d]
       }.freeze
     end
   end

--- a/lib/taxman/taxman2024/ab/t4.rb
+++ b/lib/taxman/taxman2024/ab/t4.rb
@@ -8,7 +8,7 @@ module Taxman2024
       DEFAULT_TD1 = 21_885_00.to_d
 
       RATES_AND_CONSTANTS = {
-        148_289_00.to_d => [LOWEST_RATE, 0.0.to_d],
+        148_269_00.to_d => [LOWEST_RATE, 0.0.to_d],
         177_922_00.to_d => [0.12, 2_965_00.to_d],
         237_230_00.to_d => [0.13, 4_745_00.to_d],
         355_845_00.to_d => [0.14, 7_117_00.to_d],

--- a/lib/taxman/taxman2024/bc/t2.rb
+++ b/lib/taxman/taxman2024/bc/t2.rb
@@ -4,14 +4,14 @@ module Taxman2024
   module Bc
     # Calculates the T2 factor for BC
     class T2 < T2Generic
-      S2 = 521_00.to_d
+      S2 = 547_00.to_d
 
-      LOWER_THRESHOLD = 23_179_00
-      UPPER_THRESHOLD = 37_814_00
+      LOWER_THRESHOLD = 24_338_00
+      UPPER_THRESHOLD = 39_703_00
 
       def s
         return [t4, S2].min if a <= LOWER_THRESHOLD
-        return 0.to_d if a >= UPPER_THRESHOLD
+        return 0.to_d if a > UPPER_THRESHOLD
 
         [t4, s_factor].min
       end

--- a/lib/taxman/taxman2024/bc/t4.rb
+++ b/lib/taxman/taxman2024/bc/t4.rb
@@ -5,16 +5,16 @@ module Taxman2024
     # Calculates the annualized provincial tax
     class T4 < T4Generic
       LOWEST_RATE = 0.0506.to_d
-      DEFAULT_TD1 = 11_981_00.to_d
+      DEFAULT_TD1 = 12_580_00.to_d
 
       RATES_AND_CONSTANTS = {
-        45_654_00.to_d => [LOWEST_RATE, 0.0.to_d],
-        91_310_00.to_d => [0.0770, 1_205_00.to_d],
-        104_835_00.to_d => [0.1050, 3_762_00.to_d],
-        127_299_00.to_d => [0.1229, 5_638_00.to_d],
-        172_602_00.to_d => [0.1470, 8_706_00.to_d],
-        240_716_00.to_d => [0.1680, 12_331_00.to_d],
-        BigDecimal("Infinity") => [0.2050, 21_238_00.to_d]
+        47_937_00.to_d => [LOWEST_RATE, 0.0.to_d],
+        95_875_00.to_d => [0.0770, 1_266_00.to_d],
+        110_076_00.to_d => [0.1050, 3_950_00.to_d],
+        133_664_00.to_d => [0.1229, 5_920_00.to_d],
+        181_232_00.to_d => [0.1470, 9_142_00.to_d],
+        252_752_00.to_d => [0.1680, 12_948_00.to_d],
+        BigDecimal("Infinity") => [0.2050, 22_299_00.to_d]
       }.freeze
     end
   end

--- a/lib/taxman/taxman2024/bpaf.rb
+++ b/lib/taxman/taxman2024/bpaf.rb
@@ -3,11 +3,11 @@
 module Taxman2024
   # Calculates the basic personal federal tax exemption
   class Bpaf
-    LOWER_THRESHOLD = 165_430_00.to_d
-    UPPER_THRESHOLD = 235_675_00.to_d
+    LOWER_THRESHOLD = 173_205_00.to_d
+    UPPER_THRESHOLD = 246_752_00.to_d
 
-    MAX_AMOUNT = 15_000_00.to_d
-    MIN_AMOUNT = 13_521_00.to_d
+    MAX_AMOUNT = 15_705_00.to_d
+    MIN_AMOUNT = 14_156_00.to_d
     attr_reader :ni
 
     def initialize(a:, hd:)
@@ -18,7 +18,7 @@ module Taxman2024
       return MAX_AMOUNT if ni <= LOWER_THRESHOLD
       return MIN_AMOUNT if ni >= UPPER_THRESHOLD
 
-      MAX_AMOUNT - ((ni - LOWER_THRESHOLD) * (1_479_00.to_d / 70_245_00.to_d))
+      MAX_AMOUNT - ((ni - LOWER_THRESHOLD) * (1_549_00.to_d / 73_547_00.to_d))
     end
   end
 end

--- a/lib/taxman/taxman2024/c2.rb
+++ b/lib/taxman/taxman2024/c2.rb
@@ -4,13 +4,13 @@ module Taxman2024
   # second additional CPP contributions
   class C2 < Factor
     def self.params
-      %i[pm d2 pi_ytd pi w]
+      %i[pm d2 d2q pi_ytd pi w]
     end
     attr_reader(*params)
 
     def amount
       c2 = [
-        (Cpp::MAX_ADDITIONAL * (pm / 12)) - d2,
+        (Cpp::MAX_ADDITIONAL * (pm / 12)) - (d2 + d2q),
         (pi_ytd + pi - w) * Cpp::ADDITIONAL_RATE
       ].min
 

--- a/lib/taxman/taxman2024/c2.rb
+++ b/lib/taxman/taxman2024/c2.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+module Taxman2024
+  # second additional CPP contributions
+  class C2 < Factor
+    def self.params
+      %i[pm d2 pi_ytd pi w]
+    end
+    attr_reader(*params)
+
+    def amount
+      c2 = [
+        (Cpp::MAX_ADDITIONAL * (pm / 12)) - d2,
+        (pi_ytd + pi - w) * Cpp::ADDITIONAL_RATE
+      ].min
+
+      [c2, 0].max
+    end
+  end
+end

--- a/lib/taxman/taxman2024/calculate.rb
+++ b/lib/taxman/taxman2024/calculate.rb
@@ -32,6 +32,7 @@ module Taxman2024
 
       context[:c] = context[:province] == Taxman::QC ? 0.to_d : C.amount(context)
       context[:qc_c] = context[:province] == Taxman::QC ? QcC.amount(context) : 0.to_d
+      context[:w] = W.amount(context)
       context[:c2] = C2.amount(context)
       context[:qc_ap] = QcAp.amount(context)
       context[:qc_ap1] = QcAp1.amount(context)

--- a/lib/taxman/taxman2024/calculate.rb
+++ b/lib/taxman/taxman2024/calculate.rb
@@ -33,7 +33,8 @@ module Taxman2024
       context[:c] = context[:province] == Taxman::QC ? 0.to_d : C.amount(context)
       context[:qc_c] = context[:province] == Taxman::QC ? QcC.amount(context) : 0.to_d
       context[:w] = W.amount(context)
-      context[:c2] = C2.amount(context)
+      context[:c2] = context[:province] == Taxman::QC ? 0.to_d : C2.amount(context)
+      context[:qc_c2] = context[:province] == Taxman::QC ? C2.amount(context) : 0.to_d
       context[:qc_ap] = QcAp.amount(context)
       context[:qc_ap1] = QcAp1.amount(context)
       context[:ei] = Ei.amount(context)

--- a/lib/taxman/taxman2024/calculate.rb
+++ b/lib/taxman/taxman2024/calculate.rb
@@ -32,6 +32,7 @@ module Taxman2024
 
       context[:c] = context[:province] == Taxman::QC ? 0.to_d : C.amount(context)
       context[:qc_c] = context[:province] == Taxman::QC ? QcC.amount(context) : 0.to_d
+      context[:c2] = C2.amount(context)
       context[:qc_ap] = QcAp.amount(context)
       context[:qc_ap1] = QcAp1.amount(context)
       context[:ei] = Ei.amount(context)

--- a/lib/taxman/taxman2024/cpp/constants.rb
+++ b/lib/taxman/taxman2024/cpp/constants.rb
@@ -3,12 +3,15 @@
 module Taxman2024
   module Cpp
     # Bag to hold all of the CPP constants for 2024
-    MAXIMUM_PENSIONABLE = 66_600_00.to_d
-    MAX = 3_754_45.to_d
+    MAXIMUM_PENSIONABLE = 68_500_00.to_d
+    ADDITIONAL_MAXIMUM_PENSIONABLE = 73_200_00.to_d
+    MAX = 3_867_50.to_d
+    MAX_ADDITIONAL = 188_00.to_d
     BASIC_EXEMPTION = 3_500_00.to_d
     RATE = 0.0595.to_d
+    ADDITIONAL_RATE = 0.04.to_d
     LOWER_RATE = 0.0495.to_d
-    MAX_CREDIT = 3_123_45.to_d
+    MAX_CREDIT = 3_217_50.to_d
 
     # Helper method to get the constants as a hash
     class Constants

--- a/lib/taxman/taxman2024/cpp_calculator.rb
+++ b/lib/taxman/taxman2024/cpp_calculator.rb
@@ -10,8 +10,12 @@ module Taxman2024
     end
 
     def calculate
-      context.merge(employee_cpp_contribution: (context[:c] / 100).round(2),
-                    employer_cpp_contribution: (context[:c] / 100).round(2))
+      context.merge(employee_cpp_contribution: contribution,
+                    employer_cpp_contribution: contribution)
+    end
+
+    def contribution
+      ((context[:c] + context[:c2]) / 100).round(2)
     end
   end
 end

--- a/lib/taxman/taxman2024/ei.rb
+++ b/lib/taxman/taxman2024/ei.rb
@@ -4,10 +4,10 @@ module Taxman2024
   # Calculates the employee's ei contributions for the period
   class Ei < Factor
     EI_MAX = 1_049_12.to_d
-    QC_EI_MAX = 781_05.to_d
+    QC_EI_MAX = 832_24.to_d
     MAXIMUM_INSURABLE = 63_200_00.to_d
     EMPLOYEE_RATE = 0.0166.to_d
-    QC_EMPLOYEE_RATE = 0.0127.to_d
+    QC_EMPLOYEE_RATE = 0.0132.to_d
     EMPLOYER_MATCHING = 1.4.to_d
 
     # Helper method to get the constants as a hash

--- a/lib/taxman/taxman2024/ei.rb
+++ b/lib/taxman/taxman2024/ei.rb
@@ -3,10 +3,10 @@
 module Taxman2024
   # Calculates the employee's ei contributions for the period
   class Ei < Factor
-    EI_MAX = 1_002_45.to_d
+    EI_MAX = 1_049_12.to_d
     QC_EI_MAX = 781_05.to_d
-    MAXIMUM_INSURABLE = 61_500_00.to_d
-    EMPLOYEE_RATE = 0.0163.to_d
+    MAXIMUM_INSURABLE = 63_200_00.to_d
+    EMPLOYEE_RATE = 0.0166.to_d
     QC_EMPLOYEE_RATE = 0.0127.to_d
     EMPLOYER_MATCHING = 1.4.to_d
 

--- a/lib/taxman/taxman2024/ei.rb
+++ b/lib/taxman/taxman2024/ei.rb
@@ -4,7 +4,7 @@ module Taxman2024
   # Calculates the employee's ei contributions for the period
   class Ei < Factor
     EI_MAX = 1_049_12.to_d
-    QC_EI_MAX = 832_24.to_d
+    QC_EI_MAX = 834_24.to_d
     MAXIMUM_INSURABLE = 63_200_00.to_d
     EMPLOYEE_RATE = 0.0166.to_d
     QC_EMPLOYEE_RATE = 0.0132.to_d

--- a/lib/taxman/taxman2024/f5_a.rb
+++ b/lib/taxman/taxman2024/f5_a.rb
@@ -4,7 +4,7 @@ module Taxman2024
   # Calculates the F5A factor
   class F5A < Factor
     def self.params
-      %i[pi b f5 f5q province]
+      %i[pi b_pensionable f5 f5q province]
     end
     attr_reader(*params)
 
@@ -17,9 +17,9 @@ module Taxman2024
             f5
           end
 
-      return f if b <= 0
+      return f if b_pensionable <= 0
 
-      f * ((pi - b) / pi)
+      f * ((pi - b_pensionable) / pi)
     end
   end
 end

--- a/lib/taxman/taxman2024/f5_b.rb
+++ b/lib/taxman/taxman2024/f5_b.rb
@@ -5,7 +5,7 @@ module Taxman2024
   class F5B < Factor
     # Pensionable income here _includes_ the bonus!
     def self.params
-      %i[f5 b pi f5q province]
+      %i[f5 b_pensionable pi f5q province]
     end
     attr_reader(*params)
 
@@ -18,7 +18,7 @@ module Taxman2024
             f5
           end
 
-      f * b / pi
+      f * b_pensionable / pi
     end
   end
 end

--- a/lib/taxman/taxman2024/f5_q.rb
+++ b/lib/taxman/taxman2024/f5_q.rb
@@ -4,12 +4,12 @@ module Taxman2024
   # Calculates the F5Q factor
   class F5Q < Factor
     def self.params
-      %i[qc_c c2]
+      %i[qc_c qc_c2]
     end
     attr_reader(*params)
 
     def amount
-      (qc_c * (BigDecimal("0.01") / BigDecimal("0.0640"))) + c2
+      (qc_c * (BigDecimal("0.01") / BigDecimal("0.0640"))) + qc_c2
     end
   end
 end

--- a/lib/taxman/taxman2024/f5_q.rb
+++ b/lib/taxman/taxman2024/f5_q.rb
@@ -4,12 +4,12 @@ module Taxman2024
   # Calculates the F5Q factor
   class F5Q < Factor
     def self.params
-      [:qc_c]
+      %i[qc_c c2]
     end
     attr_reader(*params)
 
     def amount
-      qc_c * (BigDecimal("0.01") / BigDecimal("0.0640"))
+      (qc_c * (BigDecimal("0.01") / BigDecimal("0.0640"))) + c2
     end
   end
 end

--- a/lib/taxman/taxman2024/k2_p_generic.rb
+++ b/lib/taxman/taxman2024/k2_p_generic.rb
@@ -24,7 +24,7 @@ module Taxman2024
     end
 
     def max_cpp_credit
-      3_123_45.to_d
+      Cpp::MAX_CREDIT
     end
 
     def cpp_portion

--- a/lib/taxman/taxman2024/mb/t4.rb
+++ b/lib/taxman/taxman2024/mb/t4.rb
@@ -5,12 +5,12 @@ module Taxman2024
     # Calculates the annualized provincial tax
     class T4 < T4Generic
       LOWEST_RATE = 0.1080.to_d
-      DEFAULT_TD1 = 19_145_00.to_d
+      DEFAULT_TD1 = 15_780_00.to_d
 
       RATES_AND_CONSTANTS = {
-        36_842_00.to_d => [LOWEST_RATE, 0.0.to_d],
-        79_625_00.to_d => [0.1275, 718_00.to_d],
-        BigDecimal("Infinity") => [0.1740, 4_421_00.to_d]
+        47_000_00.to_d => [LOWEST_RATE, 0.0.to_d],
+        100_000_00.to_d => [0.1275, 917_00.to_d],
+        BigDecimal("Infinity") => [0.1740, 5_567_00.to_d]
       }.freeze
     end
   end

--- a/lib/taxman/taxman2024/nb/t4.rb
+++ b/lib/taxman/taxman2024/nb/t4.rb
@@ -5,12 +5,12 @@ module Taxman2024
     # Calculates the annualized provincial tax
     class T4 < T4Generic
       LOWEST_RATE = 0.0940.to_d
-      DEFAULT_TD1 = 12_458_00.to_d
+      DEFAULT_TD1 = 13_044_00.to_d
 
       RATES_AND_CONSTANTS = {
-        47_715_00.to_d => [LOWEST_RATE, 0.0.to_d],
-        95_431_00.to_d => [0.1400, 2_195_00.to_d],
-        176_756_00.to_d => [0.1600, 4_104_00.to_d],
+        49_958_00.to_d => [LOWEST_RATE, 0.0.to_d],
+        99_916_00.to_d => [0.1400, 2_195_00.to_d],
+        185_064_00.to_d => [0.1600, 4_104_00.to_d],
         BigDecimal("Infinity") => [0.1950, 10_290_00.to_d]
       }.freeze
     end

--- a/lib/taxman/taxman2024/nb/t4.rb
+++ b/lib/taxman/taxman2024/nb/t4.rb
@@ -9,9 +9,9 @@ module Taxman2024
 
       RATES_AND_CONSTANTS = {
         49_958_00.to_d => [LOWEST_RATE, 0.0.to_d],
-        99_916_00.to_d => [0.1400, 2_195_00.to_d],
-        185_064_00.to_d => [0.1600, 4_104_00.to_d],
-        BigDecimal("Infinity") => [0.1950, 10_290_00.to_d]
+        99_916_00.to_d => [0.1400, 2_298_00.to_d],
+        185_064_00.to_d => [0.1600, 4_296_00.to_d],
+        BigDecimal("Infinity") => [0.1950, 10_774_00.to_d]
       }.freeze
     end
   end

--- a/lib/taxman/taxman2024/nl/t4.rb
+++ b/lib/taxman/taxman2024/nl/t4.rb
@@ -5,17 +5,17 @@ module Taxman2024
     # Calculates the annualized provincial tax
     class T4 < T4Generic
       LOWEST_RATE = 0.0870.to_d
-      DEFAULT_TD1 = 10_382_00.to_d
+      DEFAULT_TD1 = 10_818_00.to_d
 
       RATES_AND_CONSTANTS = {
-        41_457_00.to_d => [LOWEST_RATE, 0.0.to_d],
-        82_913_00.to_d => [0.1450, 2_405_00.to_d],
-        148_027_00.to_d => [0.1580, 3_482_00.to_d],
-        207_239_00.to_d => [0.1780, 6_443_00.to_d],
-        264_750_00.to_d => [0.1980, 10_588_00.to_d],
-        529_500_00.to_d => [0.2080, 13_235_00.to_d],
-        1_059_000_00.to_d => [0.2130, 15_883_00.to_d],
-        BigDecimal("Infinity") => [0.2180, 21_178_00.to_d]
+        43_198_00.to_d => [LOWEST_RATE, 0.0.to_d],
+        86_395_00.to_d => [0.1450, 2_505_00.to_d],
+        154_244_00.to_d => [0.1580, 3_629_00.to_d],
+        215_943_00.to_d => [0.1780, 6_713_00.to_d],
+        275_870_00.to_d => [0.1980, 11_032_00.to_d],
+        551_739_00.to_d => [0.2080, 13_791_00.to_d],
+        1_103_478_00.to_d => [0.2130, 16_550_00.to_d],
+        BigDecimal("Infinity") => [0.2180, 22_067_00.to_d]
       }.freeze
     end
   end

--- a/lib/taxman/taxman2024/nt/t4.rb
+++ b/lib/taxman/taxman2024/nt/t4.rb
@@ -5,13 +5,13 @@ module Taxman2024
     # Calculates the annualized provincial tax
     class T4 < T4Generic
       LOWEST_RATE = 0.0590.to_d
-      DEFAULT_TD1 = 16_593_00.to_d
+      DEFAULT_TD1 = 17_373_00.to_d
 
       RATES_AND_CONSTANTS = {
-        48_326_00.to_d => [LOWEST_RATE, 0.0.to_d],
-        96_655_00.to_d => [0.0860, 1_305_00.to_d],
-        157_139_00.to_d => [0.1220, 4_784_00.to_d],
-        BigDecimal("Infinity") => [0.1405, 7_691_00.to_d]
+        50_597_00.to_d => [LOWEST_RATE, 0.0.to_d],
+        101_198_00.to_d => [0.0860, 1_366_00.to_d],
+        164_525_00.to_d => [0.1220, 5_009_00.to_d],
+        BigDecimal("Infinity") => [0.1405, 8_053_00.to_d]
       }.freeze
     end
   end

--- a/lib/taxman/taxman2024/nu/t4.rb
+++ b/lib/taxman/taxman2024/nu/t4.rb
@@ -5,13 +5,13 @@ module Taxman2024
     # Calculates the annualized provincial tax
     class T4 < T4Generic
       LOWEST_RATE = 0.04.to_d
-      DEFAULT_TD1 = 17_925_00.to_d
+      DEFAULT_TD1 = 18_767_00.to_d
 
       RATES_AND_CONSTANTS = {
-        50_877_00.to_d => [LOWEST_RATE, 0.0.to_d],
-        101_754_00.to_d => [0.0700, 1_526_00.to_d],
-        165_429_00.to_d => [0.0900, 3_561_00.to_d],
-        BigDecimal("Infinity") => [0.1150, 7_697_00.to_d]
+        53_268_00.to_d => [LOWEST_RATE, 0.0.to_d],
+        106_537_00.to_d => [0.0700, 1_598_00.to_d],
+        173_205_00.to_d => [0.0900, 3_729_00.to_d],
+        BigDecimal("Infinity") => [0.1150, 8_059_00.to_d]
       }.freeze
     end
   end

--- a/lib/taxman/taxman2024/on/t2.rb
+++ b/lib/taxman/taxman2024/on/t2.rb
@@ -4,13 +4,16 @@ module Taxman2024
   module On
     # This calculates the T2 factor for ontario
     class T2 < T2Generic
+      V1_LOWER = 5_554_00.to_d
+      V1_UPPER = 7_108_00.to_d
+
       def v1
-        if t4 <= 5_554_00.to_d
+        if t4 <= V1_LOWER
           0
-        elsif t4 <= 7_108_00.to_d
-          0.2 * (t4 - 5_554_00.to_d)
+        elsif t4 <= V1_UPPER
+          0.2 * (t4 - V1_LOWER)
         else
-          (0.2 * (t4 - 5_554_00.to_d)) + (0.36 * (t4 - 7_108_00.to_d))
+          (0.2 * (t4 - V1_LOWER)) + (0.36 * (t4 - V1_UPPER))
         end
       end
 

--- a/lib/taxman/taxman2024/on/t2.rb
+++ b/lib/taxman/taxman2024/on/t2.rb
@@ -5,12 +5,12 @@ module Taxman2024
     # This calculates the T2 factor for ontario
     class T2 < T2Generic
       def v1
-        if t4 <= 5_315_00.to_d
+        if t4 <= 5_554_00.to_d
           0
-        elsif t4 <= 6_802_00.to_d
-          0.2 * (t4 - 5_315_00.to_d)
+        elsif t4 <= 7_108_00.to_d
+          0.2 * (t4 - 5_554_00.to_d)
         else
-          (0.2 * (t4 - 5_315_00.to_d)) + (0.36 * (t4 - 6_802_00.to_d))
+          (0.2 * (t4 - 5_554_00.to_d)) + (0.36 * (t4 - 7_108_00.to_d))
         end
       end
 
@@ -36,7 +36,7 @@ module Taxman2024
       end
 
       def s2
-        274_00.to_d
+        286_00.to_d
       end
     end
   end

--- a/lib/taxman/taxman2024/on/t4.rb
+++ b/lib/taxman/taxman2024/on/t4.rb
@@ -5,14 +5,14 @@ module Taxman2024
     # Calculates the annualized provincial tax
     class T4 < T4Generic
       LOWEST_RATE = 0.0505.to_d
-      DEFAULT_TD1 = 11_865_00.to_d
+      DEFAULT_TD1 = 12_399_00.to_d
 
       RATES_AND_CONSTANTS = {
-        49_231_00.to_d => [LOWEST_RATE, 0.0.to_d],
-        98_463_00.to_d => [0.0915.to_d, 2_018_00.to_d],
-        150_000_00.to_d => [0.1116.to_d, 3_998_00.to_d],
-        220_000_00.to_d => [0.1216.to_d, 5_498_00.to_d],
-        BigDecimal("Infinity") => [0.1316.to_d, 7_698_00.to_d]
+        51_446_00.to_d => [LOWEST_RATE, 0.0.to_d],
+        102_894_00.to_d => [0.0915.to_d, 2_109_00.to_d],
+        150_000_00.to_d => [0.1116.to_d, 4_177_00.to_d],
+        220_000_00.to_d => [0.1216.to_d, 5_677_00.to_d],
+        BigDecimal("Infinity") => [0.1316.to_d, 7_877_00.to_d]
       }.freeze
     end
   end

--- a/lib/taxman/taxman2024/pe/t2.rb
+++ b/lib/taxman/taxman2024/pe/t2.rb
@@ -2,15 +2,8 @@
 
 module Taxman2024
   module Pe
-    # Calculates the T2 factor for BC
+    # Calculates the T2 factor for PEI
     class T2 < T2Generic
-      THRESHOLD = 12_500_00.to_d
-
-      def v1
-        return 0.to_d if t4 <= THRESHOLD
-
-        BigDecimal("0.1") * (t4 - THRESHOLD)
-      end
     end
   end
 end

--- a/lib/taxman/taxman2024/pe/t4.rb
+++ b/lib/taxman/taxman2024/pe/t4.rb
@@ -4,13 +4,15 @@ module Taxman2024
   module Pe
     # Calculates the annualized provincial tax
     class T4 < T4Generic
-      LOWEST_RATE = 0.0980.to_d
-      DEFAULT_TD1 = 12_000_00.to_d
+      LOWEST_RATE = 0.0965.to_d
+      DEFAULT_TD1 = 13_500_00.to_d
 
       RATES_AND_CONSTANTS = {
-        31_984_00.to_d => [LOWEST_RATE, 0.0.to_d],
-        63_969_00.to_d => [0.1380, 1_279_00.to_d],
-        BigDecimal("Infinity") => [0.1670, 3_134_00.to_d]
+        32_656_00.to_d => [LOWEST_RATE, 0.0.to_d],
+        64_313_00.to_d => [0.1363, 1_300_00.to_d],
+        105_000_00.to_d => [0.1665, 3_242_00.to_d],
+        140_000_00.to_d => [0.1800, 4_659_00.to_d],
+        BigDecimal("Infinity") => [0.1875, 5_709_00.to_d]
       }.freeze
     end
   end

--- a/lib/taxman/taxman2024/pension_input.rb
+++ b/lib/taxman/taxman2024/pension_input.rb
@@ -8,6 +8,7 @@ module Taxman2024
                    ytd_cpp_contributions:,
                    ytd_additional_cpp_contributions:,
                    ytd_qpp_contributions:,
+                   ytd_additional_qpp_contributions:,
                    contribution_months_this_year:,
                    qc_pensionable_income_this_period: 0,
                    pensionable_non_periodic_income_this_period: 0,
@@ -20,6 +21,7 @@ module Taxman2024
       @ytd_cpp_contributions = ytd_cpp_contributions
       @ytd_additional_cpp_contributions = ytd_additional_cpp_contributions
       @ytd_qpp_contributions = ytd_qpp_contributions
+      @ytd_additional_qpp_contributions = ytd_additional_qpp_contributions
       @contribution_months_this_year = contribution_months_this_year
     end
 
@@ -36,6 +38,7 @@ module Taxman2024
       cpp_ytd = (@ytd_cpp_contributions * 100).to_d
       additional_cpp_ytd = (@ytd_additional_cpp_contributions * 100).to_d
       qpp_ytd = (@ytd_qpp_contributions * 100).to_d
+      additional_qpp_ytd = (@ytd_additional_qpp_contributions * 100).to_d
 
       {
         # T4127
@@ -46,6 +49,7 @@ module Taxman2024
         d: cpp_ytd,
         d2: additional_cpp_ytd,
         dq: qpp_ytd,
+        d2q: additional_qpp_ytd,
 
         # TP-1015.3
         qc_s3: qc_pensionable_income_this_period,

--- a/lib/taxman/taxman2024/pension_input.rb
+++ b/lib/taxman/taxman2024/pension_input.rb
@@ -4,23 +4,28 @@ module Taxman2024
   # This input collects the factors specific to cpp and qpp calculation
   class PensionInput
     def initialize(pensionable_income_this_period:,
+                   ytd_pensionable_income:,
                    ytd_cpp_contributions:,
+                   ytd_additional_cpp_contributions:,
                    ytd_qpp_contributions:,
                    contribution_months_this_year:,
                    qc_pensionable_income_this_period: 0,
                    pensionable_non_periodic_income_this_period: 0,
                    qc_pensionable_non_periodic_income_this_period: 0)
       @pensionable_income_this_period = pensionable_income_this_period
+      @ytd_pensionable_income = ytd_pensionable_income
       @qc_pensionable_income_this_period = qc_pensionable_income_this_period
       @pensionable_non_periodic_income_this_period = pensionable_non_periodic_income_this_period
       @qc_pensionable_non_periodic_income_this_period = qc_pensionable_non_periodic_income_this_period
       @ytd_cpp_contributions = ytd_cpp_contributions
+      @ytd_additional_cpp_contributions = ytd_additional_cpp_contributions
       @ytd_qpp_contributions = ytd_qpp_contributions
       @contribution_months_this_year = contribution_months_this_year
     end
 
     def translate
       pensionable_income_this_period = (@pensionable_income_this_period * 100).to_d
+      pi_ytd = (@ytd_pensionable_income * 100).to_d
       pensionable_non_periodic_income_this_period = (@pensionable_non_periodic_income_this_period * 100).to_d
       pensionable_periodic_income_this_period =
         pensionable_income_this_period - pensionable_non_periodic_income_this_period
@@ -29,14 +34,17 @@ module Taxman2024
       qc_pensionable_periodic_income_this_period =
         qc_pensionable_income_this_period - qc_pensionable_non_periodic_income_this_period
       cpp_ytd = (@ytd_cpp_contributions * 100).to_d
+      additional_cpp_ytd = (@ytd_additional_cpp_contributions * 100).to_d
       qpp_ytd = (@ytd_qpp_contributions * 100).to_d
 
       {
         # T4127
         pi: pensionable_income_this_period,
+        pi_ytd: pi_ytd,
         pi_periodic: pensionable_periodic_income_this_period,
         b_pensionable: pensionable_non_periodic_income_this_period,
         d: cpp_ytd,
+        d2: additional_cpp_ytd,
         dq: qpp_ytd,
 
         # TP-1015.3

--- a/lib/taxman/taxman2024/qpip/constants.rb
+++ b/lib/taxman/taxman2024/qpip/constants.rb
@@ -3,7 +3,7 @@
 module Taxman2024
   module Qpip
     # Bag to hold all of the CPP constants for 2024
-    MAXIMUM_INSURABLE = 91_000_00.to_d
+    MAXIMUM_INSURABLE = 94_000_00.to_d
     EMPLOYEE_RATE = 0.00494.to_d
     EMPLOYEE_MAX = MAXIMUM_INSURABLE * EMPLOYEE_RATE
     EMPLOYER_RATE = 0.00692.to_d

--- a/lib/taxman/taxman2024/qpp/constants.rb
+++ b/lib/taxman/taxman2024/qpp/constants.rb
@@ -8,7 +8,7 @@ module Taxman2024
     BASIC_EXEMPTION = 3_500_00.to_d
     RATE = 0.0640.to_d
     LOWER_RATE = 0.0540.to_d
-    QPIP_MAX = 449_54.to_d
+    QPIP_MAX = 464_36.to_d
     MAX_CREDIT = 3_510_00.to_d
 
     # Helper method to get the constants as a hash

--- a/lib/taxman/taxman2024/qpp/constants.rb
+++ b/lib/taxman/taxman2024/qpp/constants.rb
@@ -3,13 +3,13 @@
 module Taxman2024
   module Qpp
     # Bag to hold all of the QPP constants for 2024
-    MAXIMUM_PENSIONABLE = 66_600_00.to_d
-    MAX = 4_038_40.to_d
+    MAXIMUM_PENSIONABLE = 68_500_00.to_d
+    MAX = 4_160_00.to_d
     BASIC_EXEMPTION = 3_500_00.to_d
     RATE = 0.0640.to_d
     LOWER_RATE = 0.0540.to_d
     QPIP_MAX = 449_54.to_d
-    MAX_CREDIT = 3_407_40.to_d
+    MAX_CREDIT = 3_510_00.to_d
 
     # Helper method to get the constants as a hash
     class Constants

--- a/lib/taxman/taxman2024/qpp_calculator.rb
+++ b/lib/taxman/taxman2024/qpp_calculator.rb
@@ -15,7 +15,9 @@ module Taxman2024
     end
 
     def amount
-      context[:province] == Taxman::QC ? (context[:qc_c] / 100.0).round(2) : 0
+      return 0 if context[:province] != Taxman::QC
+
+      ((context[:qc_c] + context[:qc_c2]) / 100.0).round(2)
     end
   end
 end

--- a/lib/taxman/taxman2024/sk/t4.rb
+++ b/lib/taxman/taxman2024/sk/t4.rb
@@ -5,12 +5,12 @@ module Taxman2024
     # Calculates the annualized provincial tax
     class T4 < T4Generic
       LOWEST_RATE = 0.1050.to_d
-      DEFAULT_TD1 = 17_661_00.to_d
+      DEFAULT_TD1 = 18_491_00.to_d
 
       RATES_AND_CONSTANTS = {
-        49_720_00.to_d => [LOWEST_RATE, 0.0.to_d],
-        142_058_00.to_d => [0.1250, 994_00.to_d],
-        BigDecimal("Infinity") => [0.1450, 3_836_00.to_d]
+        52_057_00.to_d => [LOWEST_RATE, 0.0.to_d],
+        148_734_00.to_d => [0.1250, 1_041_00.to_d],
+        BigDecimal("Infinity") => [0.1450, 4_016_00.to_d]
       }.freeze
     end
   end

--- a/lib/taxman/taxman2024/t3.rb
+++ b/lib/taxman/taxman2024/t3.rb
@@ -6,11 +6,11 @@ module Taxman2024
     LOWEST_RATE = 0.150.to_d
 
     RATES_AND_CONSTANTS = {
-      53_359_00.to_d => [LOWEST_RATE, 0.0.to_d],
-      106_717_00.to_d => [0.205.to_d, 2_935_00.to_d],
-      165_430_00.to_d => [0.260.to_d, 8_804_00.to_d],
-      235_675_00.to_d => [0.290.to_d, 13_767_00.to_d],
-      BigDecimal("Infinity") => [0.330.to_d, 23_194_00.to_d]
+      55_867_00.to_d => [LOWEST_RATE, 0.0.to_d],
+      111_733_00.to_d => [0.205.to_d, 3_073_00.to_d],
+      173_205_00.to_d => [0.260.to_d, 9_218_00.to_d],
+      246_752_00.to_d => [0.290.to_d, 14_414_00.to_d],
+      BigDecimal("Infinity") => [0.330.to_d, 24_284_00.to_d]
     }.freeze
 
     def initialize(a:, hd:, k2_value:, tc: nil, k3: 0, tc_offset: 0)

--- a/lib/taxman/taxman2024/t3.rb
+++ b/lib/taxman/taxman2024/t3.rb
@@ -54,7 +54,7 @@ module Taxman2024
     end
 
     def cea
-      1_368_00.to_d
+      1_433_00.to_d
     end
 
     private

--- a/lib/taxman/taxman2024/w.rb
+++ b/lib/taxman/taxman2024/w.rb
@@ -1,15 +1,15 @@
 # frozen_string_literal: true
 
 module Taxman2024
-  # Calculates the F5 factor
-  class F5 < Factor
+  # used in C2 calculation
+  class W < Factor
     def self.params
-      %i[c c2]
+      %i[pi_ytd pm]
     end
     attr_reader(*params)
 
     def amount
-      (c * (BigDecimal("0.01") / BigDecimal("0.0595"))) + c2
+      [pi_ytd, Cpp::MAXIMUM_PENSIONABLE * (pm / 12)].max
     end
   end
 end

--- a/lib/taxman/taxman2024/yt/t4.rb
+++ b/lib/taxman/taxman2024/yt/t4.rb
@@ -5,15 +5,15 @@ module Taxman2024
     # Calculates the annualized provincial tax
     class T4 < T4Generic
       LOWEST_RATE = 0.0640.to_d
-      CEA = 1_368_00.to_d
-      K4P_RATE = BigDecimal("0.064")
+      CEA = 1_433_00.to_d
+      K4P_RATE = BigDecimal("0.047")
 
       RATES_AND_CONSTANTS = {
-        53_359_00.to_d => [LOWEST_RATE, 0.0.to_d],
-        106_717_00.to_d => [0.0900, 1_387_00.to_d],
-        165_430_00.to_d => [0.1090, 3_415_00.to_d],
-        500_000_00.to_d => [0.1280, 6_558_00.to_d],
-        BigDecimal("Infinity") => [0.1500, 17_558_00.to_d]
+        55_867_00.to_d => [LOWEST_RATE, 0.0.to_d],
+        111_733_00.to_d => [0.0900, 1_453_00.to_d],
+        173_205_00.to_d => [0.1090, 3_575_00.to_d],
+        500_000_00.to_d => [0.1280, 6_866_00.to_d],
+        BigDecimal("Infinity") => [0.1500, 17_866_00.to_d]
       }.freeze
 
       def tcp

--- a/lib/taxman/taxman2024/yt/t4.rb
+++ b/lib/taxman/taxman2024/yt/t4.rb
@@ -6,7 +6,7 @@ module Taxman2024
     class T4 < T4Generic
       LOWEST_RATE = 0.0640.to_d
       CEA = 1_433_00.to_d
-      K4P_RATE = BigDecimal("0.047")
+      K4P_RATE = LOWEST_RATE
 
       RATES_AND_CONSTANTS = {
         55_867_00.to_d => [LOWEST_RATE, 0.0.to_d],

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -13,6 +13,8 @@ RSpec.configure do |config|
     c.syntax = :expect
   end
 
+  config.exclude_pattern = "spec/integration/taxman2024/*"
+
   Taxman2024::Calculate.enable
 end
 

--- a/spec/taxman/taxman2024/bc/t2_spec.rb
+++ b/spec/taxman/taxman2024/bc/t2_spec.rb
@@ -3,17 +3,17 @@
 RSpec.describe Taxman2024::Bc::T2 do
   let(:t2) { described_class.new(a: a, t4: t4).amount }
 
-  context "when income is lower than $23,179" do
+  context "when income is lower than $24,338" do
     let(:t4) { described_class::S2 }
-    let(:a) { 20_000_00 }
+    let(:a) { 24_000_00 }
 
     it "subtracts the lesser of t4 and s2" do
       expect(t2).to be_zero
     end
   end
 
-  context "when income is higher than $37,814" do
-    let(:a) { 40_000_00 }
+  context "when income is higher than $39,703" do
+    let(:a) { 39_800_00 }
     let(:t4) { 5_000_00 }
 
     it "is equal to t4" do

--- a/spec/taxman/taxman2024/bpaf_spec.rb
+++ b/spec/taxman/taxman2024/bpaf_spec.rb
@@ -4,28 +4,28 @@ RSpec.describe Taxman2024::Bpaf do
   let(:bpaf) { described_class.new(a: a, hd: hd).amount }
   let(:hd) { 0 }
 
-  context "when net income is less than $165_430" do
-    let(:a) { 100_000_00 }
+  context "when net income is less than $173_205" do
+    let(:a) { 170_000_00 }
 
-    it "equals fifteen thousand" do
-      expect(bpaf).to eq 15_000_00
+    it "equals maximum" do
+      expect(bpaf).to eq 15_705_00
     end
   end
 
-  context "when net income is in between $165_430 and $235_675" do
+  context "when net income is in between $173_205 and $246_752" do
     let(:a) { 200_000_00.to_d }
 
     it "scales the bpaf down" do
-      expect(bpaf).to eq 15_000_00 - ((a - 165_430_00) * (1_479_00.to_d / 70_245_00.to_d))
+      expect(bpaf).to eq 15_705_00 - ((a - 173_205_00) * (1_549_00.to_d / 73_547_00.to_d))
     end
   end
 
-  context "when net income is over $235_675" do
+  context "when net income is over $246_752" do
     let(:a) { 200_000_00 }
     let(:hd) { 50_000_00 }
 
     it "equals the lowest bpaf amount" do
-      expect(bpaf).to eq 13_521_00
+      expect(bpaf).to eq 14_156_00
     end
   end
 end

--- a/spec/taxman/taxman2024/c2_spec.rb
+++ b/spec/taxman/taxman2024/c2_spec.rb
@@ -1,13 +1,14 @@
 # frozen_string_literal: true
 
 RSpec.describe Taxman2024::C2 do
-  subject(:c2) { described_class.new(pm: pm, d2: d2, pi_ytd: pi_ytd, pi: pi, w: w.amount).amount }
+  subject(:c2) { described_class.new(pm: pm, d2: d2, d2q: d2q, pi_ytd: pi_ytd, pi: pi, w: w.amount).amount }
 
   let(:pm) { 12 }
   let(:p) { 12 }
   let(:w) { Taxman2024::W.new(pm: pm, pi_ytd: pi_ytd) }
   let(:pi) { 4_000_00 }
   let(:d2) { 0 }
+  let(:d2q) { 0 }
   let(:pi_ytd) { 0 }
 
   context "when the employee has not reached the CPP maximum for the year" do

--- a/spec/taxman/taxman2024/c2_spec.rb
+++ b/spec/taxman/taxman2024/c2_spec.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+RSpec.describe Taxman2024::C2 do
+  subject(:c2) { described_class.new(pm: pm, d2: d2, pi_ytd: pi_ytd, pi: pi, w: w.amount).amount }
+
+  let(:pm) { 12 }
+  let(:p) { 12 }
+  let(:w) { Taxman2024::W.new(pm: pm, pi_ytd: pi_ytd) }
+  let(:pi) { 4_000_00 }
+  let(:d2) { 0 }
+  let(:pi_ytd) { 0 }
+
+  context "when the employee has not reached the CPP maximum for the year" do
+    it "calculates zero CPP2 for this period" do
+      expect(c2).to be_zero
+    end
+  end
+
+  context "when the employee has reached the CPP maximum for the year" do
+    let(:pi_ytd) { Taxman2024::Cpp::MAXIMUM_PENSIONABLE }
+
+    it "calculates non-zero CPP2 for this period" do
+      expect(c2).not_to be_zero
+    end
+
+    context "when the employee has reached the CPP2 maximum for the year" do
+      let(:d2) { Taxman2024::Cpp::MAX_ADDITIONAL }
+
+      it "calculates zero CPP2 for this period" do
+        expect(c2).to be_zero
+      end
+    end
+  end
+end

--- a/spec/taxman/taxman2024/calculate_spec.rb
+++ b/spec/taxman/taxman2024/calculate_spec.rb
@@ -37,8 +37,10 @@ RSpec.describe Taxman2024::Calculate do
     let(:c) do
       Taxman2024::PensionInput.new(
         pensionable_income_this_period: 8_000,
+        ytd_pensionable_income: 0,
         pensionable_non_periodic_income_this_period: 5_000,
         ytd_cpp_contributions: 0,
+        ytd_additional_cpp_contributions: 0,
         ytd_qpp_contributions: 0,
         contribution_months_this_year: 12
       )
@@ -118,7 +120,9 @@ RSpec.describe Taxman2024::Calculate do
     let(:c) do
       Taxman2024::PensionInput.new(
         pensionable_income_this_period: 24_695.92,
+        ytd_pensionable_income: 0,
         ytd_cpp_contributions: 0,
+        ytd_additional_cpp_contributions: 0,
         ytd_qpp_contributions: 0,
         contribution_months_this_year: 12
       )
@@ -171,7 +175,9 @@ RSpec.describe Taxman2024::Calculate do
     let(:c) do
       Taxman2024::PensionInput.new(
         pensionable_income_this_period: 3_076.92,
+        ytd_pensionable_income: 0,
         ytd_cpp_contributions: 0,
+        ytd_additional_cpp_contributions: 0,
         ytd_qpp_contributions: 0,
         contribution_months_this_year: 12
       )
@@ -221,8 +227,10 @@ RSpec.describe Taxman2024::Calculate do
     let(:c) do
       Taxman2024::PensionInput.new(
         pensionable_income_this_period: 1_000,
+        ytd_pensionable_income: 0,
         pensionable_non_periodic_income_this_period: 1_000,
         ytd_cpp_contributions: 3_754.45,
+        ytd_additional_cpp_contributions: 0,
         ytd_qpp_contributions: 0,
         contribution_months_this_year: 12
       )

--- a/spec/taxman/taxman2024/calculate_spec.rb
+++ b/spec/taxman/taxman2024/calculate_spec.rb
@@ -56,15 +56,11 @@ RSpec.describe Taxman2024::Calculate do
     end
 
     it "calculates the federal tax owed" do
-      expect(calculate.call).to match(
-        a_hash_including(federal_tax: 543.84)
-      )
+      expect(calculate.call[:federal_tax]).to eq(533.25)
     end
 
     it "calculates the provincial tax owed" do
-      expect(calculate.call).to match(
-        a_hash_including(provincial_tax: 321.17)
-      )
+      expect(calculate.call[:provincial_tax]).to eq(311.74)
     end
 
     it "calculates the bonus tax owed" do
@@ -86,15 +82,11 @@ RSpec.describe Taxman2024::Calculate do
     end
 
     it "calculates the employee ei contribution" do
-      expect(calculate.call).to match(
-        a_hash_including(employee_ei_contribution: 130.4)
-      )
+      expect(calculate.call[:employee_ei_contribution]).to eq(132.80)
     end
 
     it "calculates the employer ei contribution" do
-      expect(calculate.call).to match(
-        a_hash_including(employer_ei_contribution: 182.56)
-      )
+      expect(calculate.call[:employer_ei_contribution]).to eq(185.92)
     end
   end
 
@@ -126,7 +118,8 @@ RSpec.describe Taxman2024::Calculate do
         ytd_additional_cpp_contributions: 0,
         ytd_qpp_contributions: 0,
         ytd_additional_qpp_contributions: 0,
-        contribution_months_this_year: 12
+        contribution_months_this_year: 12,
+        pensionable_non_periodic_income_this_period: 21_619
       )
     end
 
@@ -138,9 +131,7 @@ RSpec.describe Taxman2024::Calculate do
     end
 
     it "calculates the federal tax owed" do
-      expect(calculate.call).to match(
-        a_hash_including(federal_tax: 393.38)
-      )
+      expect(calculate.call[:federal_tax]).to eq(382.81)
     end
 
     it "calculates the federal bonus tax owed" do
@@ -194,15 +185,11 @@ RSpec.describe Taxman2024::Calculate do
     end
 
     it "calculates the federal tax owed" do
-      expect(calculate.call).to match(
-        a_hash_including(federal_tax: 387.85)
-      )
+      expect(calculate.call[:federal_tax]).to eq(377.29)
     end
 
     it "calculates the provincial tax owed" do
-      expect(calculate.call).to match(
-        a_hash_including(provincial_tax: 250.68)
-      )
+      expect(calculate.call[:provincial_tax]).to eq(244.95)
     end
   end
 
@@ -249,15 +236,11 @@ RSpec.describe Taxman2024::Calculate do
     end
 
     it "calculates the federal bonus tax owed" do
-      expect(calculate.call).to match(
-        a_hash_including(federal_tax_on_bonus: 205.00)
-      )
+      expect(calculate.call[:federal_tax_on_bonus]).to eq(200.46)
     end
 
     it "calculates the provincial bonus tax owed" do
-      expect(calculate.call).to match(
-        a_hash_including(provincial_tax_on_bonus: 91.50)
-      )
+      expect(calculate.call[:provincial_tax_on_bonus]).to eq(89.75)
     end
   end
 end

--- a/spec/taxman/taxman2024/calculate_spec.rb
+++ b/spec/taxman/taxman2024/calculate_spec.rb
@@ -42,6 +42,7 @@ RSpec.describe Taxman2024::Calculate do
         ytd_cpp_contributions: 0,
         ytd_additional_cpp_contributions: 0,
         ytd_qpp_contributions: 0,
+        ytd_additional_qpp_contributions: 0,
         contribution_months_this_year: 12
       )
     end
@@ -124,6 +125,7 @@ RSpec.describe Taxman2024::Calculate do
         ytd_cpp_contributions: 0,
         ytd_additional_cpp_contributions: 0,
         ytd_qpp_contributions: 0,
+        ytd_additional_qpp_contributions: 0,
         contribution_months_this_year: 12
       )
     end
@@ -179,6 +181,7 @@ RSpec.describe Taxman2024::Calculate do
         ytd_cpp_contributions: 0,
         ytd_additional_cpp_contributions: 0,
         ytd_qpp_contributions: 0,
+        ytd_additional_qpp_contributions: 0,
         contribution_months_this_year: 12
       )
     end
@@ -232,6 +235,7 @@ RSpec.describe Taxman2024::Calculate do
         ytd_cpp_contributions: 3_754.45,
         ytd_additional_cpp_contributions: 0,
         ytd_qpp_contributions: 0,
+        ytd_additional_qpp_contributions: 0,
         contribution_months_this_year: 12
       )
     end

--- a/spec/taxman/taxman2024/cpp/constants_spec.rb
+++ b/spec/taxman/taxman2024/cpp/constants_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe Taxman2024::Cpp::Constants do
   let(:constants) { described_class.to_h }
 
   it "has the maximum pensionable income for a year" do
-    expect(constants[:cpp_maximum_pensionable]).to eq 66_600
+    expect(constants[:cpp_maximum_pensionable]).to eq 68_500
   end
 
   it "has the basic exemption" do

--- a/spec/taxman/taxman2024/cpp_calculator_spec.rb
+++ b/spec/taxman/taxman2024/cpp_calculator_spec.rb
@@ -2,17 +2,17 @@
 
 RSpec.describe Taxman2024::CppCalculator do
   let(:cpp_calc) { described_class.new(context: context) }
-  let(:context) { { c: 427_13.to_d } }
+  let(:context) { { c: 427_13.to_d, c2: 10_00.to_d } }
 
   it "adds the employee cpp contribution to context" do
     expect(cpp_calc.calculate).to match(
-      a_hash_including(employee_cpp_contribution: 427.13.to_d)
+      a_hash_including(employee_cpp_contribution: 437.13.to_d)
     )
   end
 
   it "adds the employer cpp contribution to context" do
     expect(cpp_calc.calculate).to match(
-      a_hash_including(employer_cpp_contribution: 427.13.to_d)
+      a_hash_including(employer_cpp_contribution: 437.13.to_d)
     )
   end
 end

--- a/spec/taxman/taxman2024/ei_spec.rb
+++ b/spec/taxman/taxman2024/ei_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe Taxman2024::Ei do
     let(:ie) { 5_500_00 }
 
     it "matches pdoc" do
-      expect(ei).to eq 89_65.00.to_d
+      expect(ei).to eq 91_30.00.to_d
     end
   end
 
@@ -49,7 +49,7 @@ RSpec.describe Taxman2024::Ei do
     let(:province) { Taxman::QC }
 
     it "uses the remaining contribution room" do
-      expect(ei).to eq 19_05
+      expect(ei).to eq 42_24
     end
   end
 
@@ -57,7 +57,7 @@ RSpec.describe Taxman2024::Ei do
     let(:constants) { described_class::Constants.to_h }
 
     it "has the employee rate" do
-      expect(constants[:ei_employee_rate]).to eq 0.0163
+      expect(constants[:ei_employee_rate]).to eq 0.0166
     end
 
     it "has the employer matching rate" do
@@ -65,7 +65,7 @@ RSpec.describe Taxman2024::Ei do
     end
 
     it "has the maximum insurable earnings for a year" do
-      expect(constants[:ei_maximum_insurable]).to eq 61_500.00
+      expect(constants[:ei_maximum_insurable]).to eq 63_200.00
     end
   end
 end

--- a/spec/taxman/taxman2024/f5_a_spec.rb
+++ b/spec/taxman/taxman2024/f5_a_spec.rb
@@ -3,7 +3,7 @@
 # F5A = F5 * ((PI - B)/PI)
 RSpec.describe Taxman2024::F5A do
   # We're taking the examples from https://www.canada.ca/en/revenue-agency/services/forms-publications/payroll/t4127-payroll-deductions-formulas/t4127-jan/t4127-jan-payroll-deductions-formulas-computer-programs.html#toc97
-  let(:f5a) { described_class.new(pi: pi, b: b, f5: f5, f5q: f5q, province: province).amount }
+  let(:f5a) { described_class.new(pi: pi, b_pensionable: b, f5: f5, f5q: f5q, province: province).amount }
 
   let(:f5) { 8_93.0 }
   let(:f5q) { 8_30.21 }

--- a/spec/taxman/taxman2024/f5_b_spec.rb
+++ b/spec/taxman/taxman2024/f5_b_spec.rb
@@ -3,7 +3,7 @@
 # F5B = F5 * (B/PI)
 RSpec.describe Taxman2024::F5B do
   # We're taking the examples from https://www.canada.ca/en/revenue-agency/services/forms-publications/payroll/t4127-payroll-deductions-formulas/t4127-jan/t4127-jan-payroll-deductions-formulas-computer-programs.html#toc97
-  let(:f5b) { described_class.new(pi: pi, b: b, f5: f5, f5q: f5q, province: province).amount }
+  let(:f5b) { described_class.new(pi: pi, b_pensionable: b, f5: f5, f5q: f5q, province: province).amount }
 
   let(:f5) { 52_08.40 }
   let(:f5q) { 48_42.18 }

--- a/spec/taxman/taxman2024/f5_q_spec.rb
+++ b/spec/taxman/taxman2024/f5_q_spec.rb
@@ -2,9 +2,10 @@
 
 RSpec.describe Taxman2024::F5Q do
   let(:qc_c) { 472_00.to_d }
-  let(:f5) { described_class.new(qc_c: qc_c).amount }
+  let(:c2) { 10_00.to_d }
+  let(:f5) { described_class.new(qc_c: qc_c, c2: c2).amount }
 
   it "calculates the portion due to the enhanced cpp rate" do
-    expect(f5).to be_within(0.01).of BigDecimal("73_75.00")
+    expect(f5).to be_within(0.01).of BigDecimal("83_75.00")
   end
 end

--- a/spec/taxman/taxman2024/f5_q_spec.rb
+++ b/spec/taxman/taxman2024/f5_q_spec.rb
@@ -2,8 +2,8 @@
 
 RSpec.describe Taxman2024::F5Q do
   let(:qc_c) { 472_00.to_d }
-  let(:c2) { 10_00.to_d }
-  let(:f5) { described_class.new(qc_c: qc_c, c2: c2).amount }
+  let(:qc_c2) { 10_00.to_d }
+  let(:f5) { described_class.new(qc_c: qc_c, qc_c2: qc_c2).amount }
 
   it "calculates the portion due to the enhanced cpp rate" do
     expect(f5).to be_within(0.01).of BigDecimal("83_75.00")

--- a/spec/taxman/taxman2024/f5_spec.rb
+++ b/spec/taxman/taxman2024/f5_spec.rb
@@ -2,9 +2,10 @@
 
 RSpec.describe Taxman2024::F5 do
   let(:c) { 472_00.to_d }
-  let(:f5) { described_class.new(c: c).amount }
+  let(:c2) { 10_00.to_d }
+  let(:f5) { described_class.new(c: c, c2: c2).amount }
 
   it "calculates the portion due to the enhanced cpp rate" do
-    expect(f5).to be_within(0.01).of BigDecimal("79_32.77")
+    expect(f5).to be_within(0.01).of BigDecimal("89_32.77")
   end
 end

--- a/spec/taxman/taxman2024/k2_q_spec.rb
+++ b/spec/taxman/taxman2024/k2_q_spec.rb
@@ -40,7 +40,7 @@ RSpec.describe Taxman2024::K2Q do
     let(:b_insurable) { 20_000_00.to_d }
 
     it "return correct k2q value" do
-      expect(k2q).to be_within(1).of 710_61.60.to_d
+      expect(k2q).to be_within(1).of 710_91.60.to_d
     end
   end
 end

--- a/spec/taxman/taxman2024/k2_q_spec.rb
+++ b/spec/taxman/taxman2024/k2_q_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe Taxman2024::K2Q do
   let(:b1_insurable) { 0 }
 
   it "returns correct value" do
-    expect(k2q).to be_within(1).of 616_40.49.to_d
+    expect(k2q).to be_within(1).of 620_91.00.to_d
   end
 
   context "with bonus terms" do
@@ -40,7 +40,7 @@ RSpec.describe Taxman2024::K2Q do
     let(:b_insurable) { 20_000_00.to_d }
 
     it "return correct k2q value" do
-      expect(k2q).to be_within(1).of 687_54.15.to_d
+      expect(k2q).to be_within(1).of 710_61.60.to_d
     end
   end
 end

--- a/spec/taxman/taxman2024/k2_spec.rb
+++ b/spec/taxman/taxman2024/k2_spec.rb
@@ -23,7 +23,15 @@ RSpec.describe Taxman2024::K2 do
     }
   end
 
-  before { allow(k2_obj).to receive(:rate).and_return(0.0505) }
+  context "with $54k salary monthly, no bonus" do
+    let(:i) { 4_500_00 }
+    let(:p) { 12 }
+    let(:b) { 0 }
+
+    it "matches PDOC/Greg's sheet" do
+      expect(k2).to be_within(0.01).of 509_42.25.to_d
+    end
+  end
 
   context "with $54k salary monthly, $1k bonus" do
     let(:i) { 4_500_00 }
@@ -31,6 +39,7 @@ RSpec.describe Taxman2024::K2 do
     let(:b) { 1_000_00 }
 
     it "matches PDOC/Greg's sheet" do
+      pending("Greg's sheet doesn't handle bonus here for now")
       expect(k2).to be_within(0.01).of 174_01.04.to_d
     end
   end
@@ -42,6 +51,7 @@ RSpec.describe Taxman2024::K2 do
     let(:b1) { 1_000_00 }
 
     it "matches PDOC/Greg's sheet" do
+      pending("Greg's sheet doesn't handle bonus here for now")
       expect(k2).to be_within(0.01).of 177_33.33.to_d
     end
   end
@@ -53,6 +63,7 @@ RSpec.describe Taxman2024::K2 do
     let(:b1) { 1_000_00 }
 
     it "matches PDOC/Greg's sheet" do
+      pending("Greg's sheet doesn't handle bonus here for now")
       expect(k2).to be_within(0.01).of 208_35.80.to_d
     end
   end
@@ -65,6 +76,7 @@ RSpec.describe Taxman2024::K2 do
     let(:b1) { 0 }
 
     it "matches PDOC/Greg's sheet" do
+      pending("Greg's sheet doesn't handle bonus here for now")
       expect(k2).to be_within(0.01).of 208_35.80.to_d
     end
   end

--- a/spec/taxman/taxman2024/nl/k2p_spec.rb
+++ b/spec/taxman/taxman2024/nl/k2p_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe Taxman2024::Nl::K2p do
 
     # https://docs.google.com/spreadsheets/d/1Kh9TLeYrnnqyr7BkKyuFyAWDOvkUvAlBzFAKLBB3Vbe_within(0.01).of/edit#gid=562910102
     it "matches PDOC/Greg's sheet" do
-      expect(k2p).to be_within(0.01).of 358_95.33.to_d
+      expect(k2p).to be_within(0.01).of 371_19.59.to_d
     end
   end
 end

--- a/spec/taxman/taxman2024/nl/t4_spec.rb
+++ b/spec/taxman/taxman2024/nl/t4_spec.rb
@@ -57,8 +57,8 @@ RSpec.describe Taxman2024::Nl::T4 do
     let(:k2p) { Taxman2024::Nl::K2p.new(**k2_params).amount }
 
     # https://docs.google.com/spreadsheets/d/1Kh9TLeYrnnqyr7BkKyuFyAWDOvkUvAlBzFAKLBB3VeQ/edit#gid=562910102
-    it "calculates an annualized provincial tax deduction of $8,400.62" do
-      expect(t4).to be_within(0.1).of 8_400_62.16.to_d
+    it "calculates annualized provincial tax deduction" do
+      expect(t4).to be_within(0.15).of 8_245_91.31.to_d
     end
   end
 end

--- a/spec/taxman/taxman2024/on/k2p_spec.rb
+++ b/spec/taxman/taxman2024/on/k2p_spec.rb
@@ -22,12 +22,23 @@ RSpec.describe Taxman2024::On::K2p do
     }
   end
 
+  context "with $54k salary monthly, no bonus" do
+    let(:i) { 4_500_00 }
+    let(:p) { 12 }
+    let(:b) { 0 }
+
+    it "matches PDOC/Greg's sheet" do
+      expect(k2p).to be_within(0.01).of 171_50.55.to_d
+    end
+  end
+
   context "with $54k salary monthly, $1k bonus" do
     let(:i) { 4_500_00 }
     let(:p) { 12 }
     let(:b) { 1_000_00 }
 
     it "matches PDOC/Greg's sheet" do
+      pending("Greg's sheet doesn't handle bonus here for now")
       expect(k2p).to be_within(0.01).of 174_01.04.to_d
     end
   end
@@ -39,6 +50,7 @@ RSpec.describe Taxman2024::On::K2p do
     let(:b1) { 1_000_00 }
 
     it "matches PDOC/Greg's sheet" do
+      pending("Greg's sheet doesn't handle bonus here for now")
       expect(k2p).to be_within(0.01).of 177_33.33.to_d
     end
   end
@@ -50,6 +62,7 @@ RSpec.describe Taxman2024::On::K2p do
     let(:b1) { 1_000_00 }
 
     it "matches PDOC/Greg's sheet" do
+      pending("Greg's sheet doesn't handle bonus here for now")
       expect(k2p).to be_within(0.01).of 208_35.80.to_d
     end
   end
@@ -62,6 +75,7 @@ RSpec.describe Taxman2024::On::K2p do
     let(:b1) { 0 }
 
     it "matches PDOC/Greg's sheet" do
+      pending("Greg's sheet doesn't handle bonus here for now")
       expect(k2p).to be_within(0.01).of 208_35.80.to_d
     end
   end

--- a/spec/taxman/taxman2024/on/t4_spec.rb
+++ b/spec/taxman/taxman2024/on/t4_spec.rb
@@ -57,8 +57,8 @@ RSpec.describe Taxman2024::On::T4 do
     let(:k2p) { Taxman2024::On::K2p.new(**k2_params).amount }
 
     # https://docs.google.com/spreadsheets/d/1q0tv_4IMqdL23wLRg49VikhXRC5tsy7oxGc5at71fzw/edit#gid=89378561
-    it "calculates an annualized provincial tax deduction of $2,106.92" do
-      expect(t4).to be_within(0.2).of 2_106_92.to_d
+    it "calculates annualized provincial tax deduction" do
+      expect(t4).to be_within(0.2).of 1_988_13.53.to_d
     end
   end
 end

--- a/spec/taxman/taxman2024/pe/t2_spec.rb
+++ b/spec/taxman/taxman2024/pe/t2_spec.rb
@@ -16,8 +16,8 @@ RSpec.describe Taxman2024::Pe::T2 do
     let(:t4) { 12_500_00.to_d + surplus }
     let(:surplus) { 15_000_00 }
 
-    it "has a ten percent surtax on the amount over the threshold" do
-      expect(t2).to eq (0.1 * surplus) + t4
+    it "has no surtax" do
+      expect(t2).to eq t4
     end
   end
 end

--- a/spec/taxman/taxman2024/pension_input_spec.rb
+++ b/spec/taxman/taxman2024/pension_input_spec.rb
@@ -8,6 +8,7 @@ RSpec.describe Taxman2024::PensionInput do
       ytd_cpp_contributions: cpp_ytd,
       ytd_additional_cpp_contributions: additional_cpp_ytd,
       ytd_qpp_contributions: qpp_ytd,
+      ytd_additional_qpp_contributions: additional_cpp_ytd,
       contribution_months_this_year: pm,
       pensionable_non_periodic_income_this_period: b_pensionable,
       qc_pensionable_income_this_period: qc_s3,
@@ -19,6 +20,7 @@ RSpec.describe Taxman2024::PensionInput do
   let(:pi_ytd) { 7_000 }
   let(:cpp_ytd) { 114 }
   let(:additional_cpp_ytd) { 0 }
+  let(:additional_qpp_ytd) { 0 }
   let(:qpp_ytd) { 441 }
   let(:pm) { 12 }
   let(:b_pensionable) { 111 }
@@ -31,6 +33,7 @@ RSpec.describe Taxman2024::PensionInput do
       pi_ytd: 7_000_00.to_d,
       d: 114_00.to_d,
       d2: 0.to_d,
+      d2q: 0.to_d,
       b_pensionable: 111_00.to_d,
       pi_periodic: 3_389_00.to_d,
       dq: 441_00.to_d,

--- a/spec/taxman/taxman2024/pension_input_spec.rb
+++ b/spec/taxman/taxman2024/pension_input_spec.rb
@@ -4,7 +4,9 @@ RSpec.describe Taxman2024::PensionInput do
   let(:cpp_input) do
     described_class.new(
       pensionable_income_this_period: pi,
+      ytd_pensionable_income: pi_ytd,
       ytd_cpp_contributions: cpp_ytd,
+      ytd_additional_cpp_contributions: additional_cpp_ytd,
       ytd_qpp_contributions: qpp_ytd,
       contribution_months_this_year: pm,
       pensionable_non_periodic_income_this_period: b_pensionable,
@@ -14,7 +16,9 @@ RSpec.describe Taxman2024::PensionInput do
   end
 
   let(:pi) { 3_500 }
+  let(:pi_ytd) { 7_000 }
   let(:cpp_ytd) { 114 }
+  let(:additional_cpp_ytd) { 0 }
   let(:qpp_ytd) { 441 }
   let(:pm) { 12 }
   let(:b_pensionable) { 111 }
@@ -24,7 +28,9 @@ RSpec.describe Taxman2024::PensionInput do
   let(:form) do
     {
       pi: 3_500_00.to_d,
+      pi_ytd: 7_000_00.to_d,
       d: 114_00.to_d,
+      d2: 0.to_d,
       b_pensionable: 111_00.to_d,
       pi_periodic: 3_389_00.to_d,
       dq: 441_00.to_d,

--- a/spec/taxman/taxman2024/qpp_calculator_spec.rb
+++ b/spec/taxman/taxman2024/qpp_calculator_spec.rb
@@ -4,17 +4,17 @@ RSpec.describe Taxman2024::QppCalculator do
   let(:qpp_calc) { described_class.new(context: context) }
 
   context "when paying taxes in Quebec" do
-    let(:context) { { qc_c: 427_13.to_d, province: Taxman::QC } }
+    let(:context) { { qc_c: 427_13.to_d, qc_c2: 2_00, province: Taxman::QC } }
 
     it "adds the employee Qpp contribution to context" do
       expect(qpp_calc.calculate).to match(
-        a_hash_including(employee_qpp_contribution: 427.13.to_d)
+        a_hash_including(employee_qpp_contribution: 429.13.to_d)
       )
     end
 
     it "adds the employer qpp contribution to context" do
       expect(qpp_calc.calculate).to match(
-        a_hash_including(employer_qpp_contribution: 427.13.to_d)
+        a_hash_including(employer_qpp_contribution: 429.13.to_d)
       )
     end
   end

--- a/spec/taxman/taxman2024/t3_spec.rb
+++ b/spec/taxman/taxman2024/t3_spec.rb
@@ -51,8 +51,8 @@ RSpec.describe Taxman2024::T3 do
     end
     let(:k2) { Taxman2024::K2.new(**k2_params).amount }
 
-    it "calculates an annualized tax of $5,069.28" do
-      expect(t3).to be_within(0.1).of 5_069_28 # This is from pdoc, they only give us cents
+    it "calculates annualized tax" do
+      expect(t3).to be_within(0.1).of 4_944_12.62
     end
   end
 
@@ -74,8 +74,8 @@ RSpec.describe Taxman2024::T3 do
 
     let(:k2) { Taxman2024::K2.new(**k2_params).amount }
 
-    it "calculates an annualized tax of $43,594.31" do
-      expect(t3).to be_within(0.01).of 43_594_30.56.to_d
+    it "calculates annualized tax" do
+      expect(t3).to be_within(0.01).of 42_786_17.61.to_d
     end
   end
 end

--- a/spec/taxman/taxman2024/tax_calculator_spec.rb
+++ b/spec/taxman/taxman2024/tax_calculator_spec.rb
@@ -55,11 +55,11 @@ RSpec.describe Taxman2024::TaxCalculator do
   let(:tax) { described_class.new(context: context).calculate }
 
   it "matches the federal taxes on PDOC/Greg's sheet" do
-    expect(tax[:federal_tax]).to be_within(0.1).of 543.84.to_d
+    expect(tax[:federal_tax]).to be_within(0.1).of 533.25.to_d
   end
 
   it "matches the provincial taxes on PDOC/Greg's sheet" do
-    expect(tax[:provincial_tax]).to be_within(0.1).of 321.17.to_d
+    expect(tax[:provincial_tax]).to be_within(0.1).of 311.74.to_d
   end
 
   context "when a required parameter is missing" do
@@ -71,7 +71,7 @@ RSpec.describe Taxman2024::TaxCalculator do
   end
 
   it "matches the expected T3 amount" do
-    expect(tax[:t3]).to be_within(0.1).of 2_827_972.33.to_d
+    expect(tax[:t3]).to be_within(0.1).of 27_729_11.53.to_d
   end
 
   context "when previously in Quebec" do
@@ -80,7 +80,7 @@ RSpec.describe Taxman2024::TaxCalculator do
     end
 
     it "matches the expected T3 amount" do
-      expect(tax[:t3]).to be_within(0.1).of 2_889_860.83.to_d
+      expect(tax[:t3]).to be_within(0.1).of 28_369_10.83.to_d
     end
   end
 
@@ -149,6 +149,7 @@ RSpec.describe Taxman2024::TaxCalculator do
     end
 
     it "matches the expected T3 amount" do
+      pending("QC updates not implemented yet")
       expect(tax[:t3]).to be_within(0.1).of 618_658.51.to_d
     end
   end

--- a/spec/taxman/taxman2024/yt/t4_spec.rb
+++ b/spec/taxman/taxman2024/yt/t4_spec.rb
@@ -7,16 +7,16 @@ RSpec.describe Taxman2024::Yt::T4 do
     context "when a is less than CEA" do
       let(:a) { 1_000_00 }
 
-      it "equals 4.7% times a" do
-        expect(t4.k4p).to eq 0.047 * a
+      it "equals 6.4% times a" do
+        expect(t4.k4p).to eq 0.064 * a
       end
     end
 
     context "when a is greater than CEA" do
       let(:a) { 2_000_00 }
 
-      it "equals 4.7% times CEA" do
-        expect(t4.k4p).to eq 0.047 * described_class::CEA
+      it "equals 6.4% times CEA" do
+        expect(t4.k4p).to eq 0.064 * described_class::CEA
       end
     end
   end

--- a/spec/taxman/taxman2024/yt/t4_spec.rb
+++ b/spec/taxman/taxman2024/yt/t4_spec.rb
@@ -7,16 +7,16 @@ RSpec.describe Taxman2024::Yt::T4 do
     context "when a is less than CEA" do
       let(:a) { 1_000_00 }
 
-      it "equals 6.4% times a" do
-        expect(t4.k4p).to eq 0.064 * a
+      it "equals 4.7% times a" do
+        expect(t4.k4p).to eq 0.047 * a
       end
     end
 
     context "when a is greater than CEA" do
       let(:a) { 2_000_00 }
 
-      it "equals 6.4% times CEA" do
-        expect(t4.k4p).to eq 0.064 * described_class::CEA
+      it "equals 4.7% times CEA" do
+        expect(t4.k4p).to eq 0.047 * described_class::CEA
       end
     end
   end


### PR DESCRIPTION
Adds support for 2024 calculations

Note that all the changes were previously reviewed and approved when merged into `2024` branch.

Also note that 2024 has to be [explicitly enabled](https://github.com/Humi-HR/taxman/blob/master/lib/taxman/taxman2024/calculate.rb#L72), so merely updating a dependency to use this gem does not expose 2024 code yet.

