### PR TITLE
Add rounding to bpans

### DIFF
--- a/lib/taxman/taxman2024/bpans.rb
+++ b/lib/taxman/taxman2024/bpans.rb
@@ -16,7 +16,8 @@ module Taxman2024
       return MAX_VALUE if a <= 25_000_00.to_d
       return MIN_VALUE if a >= 75_000_00.to_d
 
-      MAX_VALUE - ((a - 25_000_00) * 0.06)
+      # Round result to the cent
+      (MAX_VALUE - ((a - 25_000_00) * 0.06)).round
     end
   end
 end


### PR DESCRIPTION
The CRA text is hilariously bad:

"If Nova Scotia’s basic personal amount (BPANS) has three or more digits after the decimal point, increase the second digit by one if the third digit is five or more, and drop the third digit. If the third digit after the decimal point is less than five, drop the third digit."

So, round to the cent (which we use as the base value).