### PR TITLE
Update release-please to v4

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -33,12 +33,10 @@ jobs:
     needs: [tests]
     runs-on: ubuntu-latest
     steps:
-      - uses: google-github-actions/release-please-action@v3
+      - uses: google-github-actions/release-please-action@v4
         with:
           # In order to publish a release that triggers another workflow,
           # we use a custom Personal Access Token rather than default
           # secrets.GITHUB_TOKEN. 
           token: ${{ secrets.HUMI_CI_TOKEN }}
-          release-type: ruby
-          package-name: taxman
-          version-file: lib/taxman/version.rb
+          manifest-file: .release-please-manifest.json

--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,0 +1,9 @@
+{
+  "packages": {
+    ".": {
+      "release-type": "ruby",
+      "version-file": "lib/taxman/version.rb",
+      "package-name": "taxman"
+    }
+  }
+}


### PR DESCRIPTION
The new version needs a dedicated manifest file to set the
configurations that we had been setting before in v3. This has not
really been tested, but should be triggered by PRs merged into master
and will then let us know if things work as expected.

Details on the v3 to v4 upgrade:
https://github.com/google-github-actions/release-please-action#upgrading-from-v3-to-v4
